### PR TITLE
refactor: Add REJECTED status to Signature Request [SFEQS-1147]

### DIFF
--- a/apps/io-func-sign-issuer/openapi.yaml
+++ b/apps/io-func-sign-issuer/openapi.yaml
@@ -595,6 +595,10 @@ components:
           $ref: "#/components/schemas/Timestamp"
         updated_at:
           $ref: "#/components/schemas/Timestamp"
+        signed_at:
+          $ref: "#/components/schemas/Timestamp"
+        reject_reason:
+          type: string
         qr_code_url:
           type: string
           format: uri

--- a/apps/io-func-sign-issuer/openapi.yaml
+++ b/apps/io-func-sign-issuer/openapi.yaml
@@ -531,7 +531,7 @@ components:
           required:
             - uploaded_at
 
-    DocumentUploaded:
+    DocumentReady:
       allOf:
         - $ref: "#/components/schemas/Document"
         - type: object
@@ -565,7 +565,7 @@ components:
       oneOf:
         - $ref: "#/components/schemas/DocumentToBeUploaded"
         - $ref: "#/components/schemas/DocumentToBeValidated"
-        - $ref: "#/components/schemas/DocumentUploaded"
+        - $ref: "#/components/schemas/DocumentReady"
         - $ref: "#/components/schemas/DocumentRejected"
 
     SignatureRequestDetailView:

--- a/apps/io-func-sign-issuer/openapi.yaml
+++ b/apps/io-func-sign-issuer/openapi.yaml
@@ -580,6 +580,7 @@ components:
             - READY
             - WAIT_FOR_SIGNATURE
             - SIGNED
+            - REJECTED
         dossier_id:
           $ref: "#/components/schemas/Id"
         signer_id:

--- a/apps/io-func-sign-issuer/src/infra/http/decoders/signature-request.ts
+++ b/apps/io-func-sign-issuer/src/infra/http/decoders/signature-request.ts
@@ -18,7 +18,9 @@ import { makeRequireIssuer } from "./issuer";
 const requireSignatureRequestIdFromPath = flow(
   path("signatureRequestId"),
   E.fromOption(() => new Error(`missing "id" in path`)),
-  E.chainW(validate(SignatureRequest.props.id, `invalid "id" supplied`))
+  E.chainW(
+    validate(SignatureRequest.types[0].props.id, `invalid "id" supplied`)
+  )
 );
 
 export const makeRequireSignatureRequest = (

--- a/apps/io-func-sign-issuer/src/infra/http/decoders/signature-request.ts
+++ b/apps/io-func-sign-issuer/src/infra/http/decoders/signature-request.ts
@@ -20,7 +20,9 @@ import { EntityNotFoundError } from "@internal/io-sign/error";
 const requireSignatureRequestIdFromPath = flow(
   path("signatureRequestId"),
   E.fromOption(() => new Error(`Missing "id" in path`)),
-  E.chainW(validate(SignatureRequest.props.id, `Invalid "id" supplied.`))
+  E.chainW(
+    validate(SignatureRequest.types[0].props.id, `Invalid "id" supplied.`)
+  )
 );
 
 export const makeRequireSignatureRequest = (

--- a/apps/io-func-sign-issuer/src/infra/http/encoders/signature-request.ts
+++ b/apps/io-func-sign-issuer/src/infra/http/encoders/signature-request.ts
@@ -33,23 +33,42 @@ export const SignatureRequestToApiModel: E.Encoder<
     id,
     dossierId: dossier_id,
     signerId: signer_id,
-    status,
     createdAt: created_at,
     updatedAt: updated_at,
     expiresAt: expires_at,
     documents,
-  }) => ({
-    id,
-    dossier_id,
-    signer_id,
-    status: toApiModelEnum(status),
-    created_at,
-    updated_at,
-    expires_at,
-    documents: documents.map(DocumentToApiModel.encode),
-    // here we have to handle the dynamic QR Code
-    qr_code_url: ["DRAFT", "READ"].includes(status)
-      ? void 0
-      : "https://place-holder.com/qr-code",
-  }),
+    ...additionals
+  }) => {
+    const commonFields = {
+      id,
+      dossier_id,
+      signer_id,
+      status: toApiModelEnum(additionals.status),
+      created_at,
+      updated_at,
+      expires_at,
+      documents: documents.map(DocumentToApiModel.encode),
+      // here we have to handle the dynamic QR Code
+      qr_code_url: ["DRAFT", "READ"].includes(additionals.status)
+        ? void 0
+        : "https://place-holder.com/qr-code",
+    };
+    switch (additionals.status) {
+      case "SIGNED": {
+        return {
+          ...commonFields,
+          signed_at: additionals.signedAt,
+        };
+      }
+      case "REJECTED": {
+        return {
+          ...commonFields,
+          reject_reason: additionals.rejectedReason,
+        };
+      }
+      default: {
+        return commonFields;
+      }
+    }
+  },
 };

--- a/apps/io-func-sign-issuer/src/infra/http/encoders/signature-request.ts
+++ b/apps/io-func-sign-issuer/src/infra/http/encoders/signature-request.ts
@@ -49,7 +49,7 @@ export const SignatureRequestToApiModel: E.Encoder<
       expires_at,
       documents: documents.map(DocumentToApiModel.encode),
       // here we have to handle the dynamic QR Code
-      qr_code_url: ["DRAFT", "READ"].includes(additionals.status)
+      qr_code_url: ["DRAFT", "READY"].includes(additionals.status)
         ? void 0
         : "https://place-holder.com/qr-code",
     };

--- a/apps/io-func-sign-issuer/src/infra/http/encoders/signature-request.ts
+++ b/apps/io-func-sign-issuer/src/infra/http/encoders/signature-request.ts
@@ -20,6 +20,8 @@ const toApiModelEnum = (
       return SignatureRequestStatusEnum.WAIT_FOR_SIGNATURE;
     case "SIGNED":
       return SignatureRequestStatusEnum.SIGNED;
+    case "REJECTED":
+      return SignatureRequestStatusEnum.REJECTED;
   }
 };
 

--- a/apps/io-func-sign-issuer/src/infra/http/encoders/signature-request.ts
+++ b/apps/io-func-sign-issuer/src/infra/http/encoders/signature-request.ts
@@ -37,33 +37,36 @@ export const SignatureRequestToApiModel: E.Encoder<
     updatedAt: updated_at,
     expiresAt: expires_at,
     documents,
-    ...additionals
+    ...extras
   }) => {
     const commonFields = {
       id,
       dossier_id,
       signer_id,
-      status: toApiModelEnum(additionals.status),
+      status: toApiModelEnum(extras.status),
       created_at,
       updated_at,
       expires_at,
       documents: documents.map(DocumentToApiModel.encode),
       // here we have to handle the dynamic QR Code
-      qr_code_url: ["DRAFT", "READY"].includes(additionals.status)
-        ? void 0
+      qr_code_url: [
+        SignatureRequestStatusEnum.DRAFT,
+        SignatureRequestStatusEnum.READY,
+      ].includes(toApiModelEnum(extras.status))
+        ? undefined
         : "https://place-holder.com/qr-code",
     };
-    switch (additionals.status) {
+    switch (extras.status) {
       case "SIGNED": {
         return {
           ...commonFields,
-          signed_at: additionals.signedAt,
+          signed_at: extras.signedAt,
         };
       }
       case "REJECTED": {
         return {
           ...commonFields,
-          reject_reason: additionals.rejectedReason,
+          reject_reason: extras.rejectedReason,
         };
       }
       default: {

--- a/apps/io-func-sign-issuer/src/signature-request.ts
+++ b/apps/io-func-sign-issuer/src/signature-request.ts
@@ -26,23 +26,29 @@ import { findFirst, findIndex, updateAt } from "fp-ts/lib/Array";
 import { Dossier } from "./dossier";
 import { Issuer } from "./issuer";
 
-export const SignatureRequest = t.type({
-  id: Id,
-  issuerId: Issuer.props.id,
-  signerId: Signer.props.id,
-  dossierId: Dossier.props.id,
-  status: t.keyof({
-    DRAFT: null,
-    READY: null,
-    WAIT_FOR_SIGNATURE: null,
-    SIGNED: null,
-    REJECTED: null,
+export const SignatureRequest = t.intersection([
+  t.type({
+    id: Id,
+    issuerId: Issuer.props.id,
+    signerId: Signer.props.id,
+    dossierId: Dossier.props.id,
+    status: t.keyof({
+      DRAFT: null,
+      READY: null,
+      WAIT_FOR_SIGNATURE: null,
+      SIGNED: null,
+      REJECTED: null,
+    }),
+    createdAt: IsoDateFromString,
+    updatedAt: IsoDateFromString,
+    expiresAt: IsoDateFromString,
+    documents: t.array(Document),
   }),
-  createdAt: IsoDateFromString,
-  updatedAt: IsoDateFromString,
-  expiresAt: IsoDateFromString,
-  documents: t.array(Document),
-});
+  t.partial({
+    signedAt: IsoDateFromString,
+    rejectedReason: t.string,
+  }),
+]);
 
 export type SignatureRequest = t.TypeOf<typeof SignatureRequest>;
 

--- a/apps/io-func-sign-issuer/src/signature-request.ts
+++ b/apps/io-func-sign-issuer/src/signature-request.ts
@@ -36,6 +36,7 @@ export const SignatureRequest = t.type({
     READY: null,
     WAIT_FOR_SIGNATURE: null,
     SIGNED: null,
+    REJECTED: null,
   }),
   createdAt: IsoDateFromString,
   updatedAt: IsoDateFromString,

--- a/apps/io-func-sign-issuer/src/upload.ts
+++ b/apps/io-func-sign-issuer/src/upload.ts
@@ -11,13 +11,14 @@ import { pipe } from "fp-ts/lib/function";
 import { EntityNotFoundError } from "@internal/io-sign/error";
 import { UrlFromString } from "@pagopa/ts-commons/lib/url";
 import { getDocument, SignatureRequest } from "./signature-request";
+import { Issuer } from "./issuer";
 
 export const UploadMetadata = t.intersection([
   t.type({
     id: Id,
-    documentId: Id,
-    signatureRequestId: Id,
-    issuerId: Id,
+    documentId: Document.types[0].props.id,
+    signatureRequestId: SignatureRequest.types[0].props.id,
+    issuerId: Issuer.props.id,
     createdAt: IsoDateFromString,
     updatedAt: IsoDateFromString,
     validated: t.boolean,

--- a/apps/io-func-sign-issuer/src/upload.ts
+++ b/apps/io-func-sign-issuer/src/upload.ts
@@ -11,14 +11,13 @@ import { pipe } from "fp-ts/lib/function";
 import { EntityNotFoundError } from "@internal/io-sign/error";
 import { UrlFromString } from "@pagopa/ts-commons/lib/url";
 import { getDocument, SignatureRequest } from "./signature-request";
-import { Issuer } from "./issuer";
 
 export const UploadMetadata = t.intersection([
   t.type({
     id: Id,
-    documentId: Document.types[0].props.id,
-    signatureRequestId: SignatureRequest.types[0].props.id,
-    issuerId: Issuer.props.id,
+    documentId: Id,
+    signatureRequestId: Id,
+    issuerId: Id,
     createdAt: IsoDateFromString,
     updatedAt: IsoDateFromString,
     validated: t.boolean,

--- a/apps/io-func-sign-issuer/src/upload.ts
+++ b/apps/io-func-sign-issuer/src/upload.ts
@@ -17,7 +17,7 @@ export const UploadMetadata = t.intersection([
   t.type({
     id: Id,
     documentId: Document.types[0].props.id,
-    signatureRequestId: SignatureRequest.props.id,
+    signatureRequestId: SignatureRequest.types[0].props.id,
     issuerId: Issuer.props.id,
     createdAt: IsoDateFromString,
     updatedAt: IsoDateFromString,

--- a/packages/io-sign/src/document.ts
+++ b/packages/io-sign/src/document.ts
@@ -83,7 +83,7 @@ const DocumentToBeValidated = t.type({
   uploadedAt: IsoDateFromString,
 });
 
-const DocumentUploaded = t.type({
+const DocumentReady = t.type({
   status: t.literal("READY"),
   uploadedAt: IsoDateFromString,
   url: t.string,
@@ -106,7 +106,7 @@ export const Document = t.intersection([
   t.union([
     DocumentToBeUploaded,
     DocumentToBeValidated,
-    DocumentUploaded,
+    DocumentReady,
     DocumentRejected,
   ]),
 ]);


### PR DESCRIPTION
This PR add `REJECTED` status to Signature Request with `rejected_reason` and `uploaded_at` fields. 