### PR TITLE
Enhance error handling [SFEQS-1126]

### DIFF
--- a/apps/io-func-sign-issuer/.prettierignore
+++ b/apps/io-func-sign-issuer/.prettierignore
@@ -1,0 +1,2 @@
+dist 
+coverage

--- a/apps/io-func-sign-issuer/openapi.yaml
+++ b/apps/io-func-sign-issuer/openapi.yaml
@@ -327,10 +327,6 @@ components:
             An absolute URI that identifies the specific occurrence of the
             problem. It may or may not yield further information if
             dereferenced.
-      required:
-        - title
-        - status
-        - detail
 
     Clause:
       type: object

--- a/apps/io-func-sign-issuer/package.json
+++ b/apps/io-func-sign-issuer/package.json
@@ -18,7 +18,7 @@
     "@azure/storage-queue": "^12.11.0",
     "@internal/io-sign": "*",
     "@internal/pdv-tokenizer": "*",
-    "@pagopa/handler-kit": "^0.3.3",
+    "@pagopa/handler-kit": "^0.4.2",
     "@pagopa/ts-commons": "^10.10.0",
     "date-fns": "^2.29.3",
     "fp-ts": "^2.13.1",

--- a/apps/io-func-sign-issuer/src/app/use-cases/validate-upload.ts
+++ b/apps/io-func-sign-issuer/src/app/use-cases/validate-upload.ts
@@ -7,10 +7,10 @@ import {
   GetSignatureRequest,
   markDocumentAsReady,
   markDocumentAsRejected,
-  signatureRequestNotFoundError,
   startValidationOnDocument,
   UpsertSignatureRequest,
 } from "../../signature-request";
+import { EntityNotFoundError } from "@internal/io-sign/error";
 
 export const makeValidateUpload =
   (
@@ -26,7 +26,14 @@ export const makeValidateUpload =
           getSignatureRequest(uploadMetadata.signatureRequestId)(
             uploadMetadata.issuerId
           ),
-          TE.chain(TE.fromOption(() => signatureRequestNotFoundError)),
+          TE.chain(
+            TE.fromOption(
+              () =>
+                new EntityNotFoundError(
+                  "The specified Signature Request does not exists."
+                )
+            )
+          ),
           TE.chainEitherK(startValidationOnDocument(uploadMetadata.documentId)),
           TE.chain(upsertSignatureRequest)
         ),

--- a/apps/io-func-sign-issuer/src/dossier.ts
+++ b/apps/io-func-sign-issuer/src/dossier.ts
@@ -10,7 +10,6 @@ import { IsoDateFromString } from "@pagopa/ts-commons/lib/dates";
 import { Id, id as newId } from "@internal/io-sign/id";
 import { DocumentMetadata } from "@internal/io-sign/document";
 
-import { EntityNotFoundError } from "@internal/io-sign/error";
 import { Issuer } from "./issuer";
 
 export const DocumentsMetadata = tx.nonEmptyArray(DocumentMetadata);
@@ -41,5 +40,3 @@ export type InsertDossier = (dossier: Dossier) => TE.TaskEither<Error, Dossier>;
 export type GetDossier = (
   dossierId: Dossier["id"]
 ) => (issuerId: Issuer["id"]) => TE.TaskEither<Error, O.Option<Dossier>>;
-
-export const dossierNotFoundError = new EntityNotFoundError("Dossier");

--- a/apps/io-func-sign-issuer/src/infra/__mocks__/signer.ts
+++ b/apps/io-func-sign-issuer/src/infra/__mocks__/signer.ts
@@ -1,3 +1,6 @@
+// this mock does not work due the split of the application entries
+// it affects "createSignatureRequest"
+
 import {
   GetSigner,
   GetSignerByFiscalCode,

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/create-dossier.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/create-dossier.ts
@@ -8,7 +8,7 @@ import { sequenceS } from "fp-ts/lib/Apply";
 import { flow, identity, pipe } from "fp-ts/lib/function";
 
 import { createHandler } from "@pagopa/handler-kit";
-import { HttpRequest, error, created } from "@pagopa/handler-kit/lib/http";
+import { HttpRequest } from "@pagopa/handler-kit/lib/http";
 import * as azure from "@pagopa/handler-kit/lib/azure";
 
 import {
@@ -26,6 +26,7 @@ import { DossierToApiModel } from "../../http/encoders/dossier";
 import { makeInsertDossier } from "../cosmos/dossier";
 import { mockGetIssuerBySubscriptionId } from "../../__mocks__/issuer";
 import { getConfigFromEnvironment } from "../../../app/config";
+import { created, error } from "@internal/io-sign/infra/http/response";
 
 const makeCreateDossierHandler = (db: CosmosDatabase) => {
   const createDossierUseCase = pipe(db, makeInsertDossier, makeCreateDossier);

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/get-signature-request.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/get-signature-request.ts
@@ -3,7 +3,7 @@ import { Database as CosmosDatabase, CosmosClient } from "@azure/cosmos";
 import * as E from "fp-ts/lib/Either";
 import * as TE from "fp-ts/lib/TaskEither";
 
-import { error, success } from "@pagopa/handler-kit/lib/http";
+import { error, success } from "@internal/io-sign/infra/http/response";
 
 import * as azure from "@pagopa/handler-kit/lib/azure";
 

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/get-signer.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/get-signer.ts
@@ -1,9 +1,4 @@
-import {
-  body,
-  error,
-  HttpRequest,
-  success,
-} from "@pagopa/handler-kit/lib/http";
+import { HttpRequest } from "@pagopa/handler-kit/lib/http";
 import { Signer, signerNotFoundError } from "@internal/io-sign/signer";
 import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
 import * as RE from "fp-ts/lib/ReaderEither";
@@ -15,7 +10,7 @@ import { flow, pipe } from "fp-ts/lib/function";
 import * as azure from "@pagopa/handler-kit/lib/azure";
 
 import * as TE from "fp-ts/lib/TaskEither";
-import { validate } from "@pagopa/handler-kit/lib/validation";
+
 import * as O from "fp-ts/lib/Option";
 import { createHandler } from "@pagopa/handler-kit";
 import { GetSignerByFiscalCodeBody } from "../../http/models/GetSignerByFiscalCodeBody";
@@ -24,10 +19,14 @@ import { SignerToApiModel } from "../../http/encoders/signer";
 import { SignerDetailView } from "../../http/models/SignerDetailView";
 import { mockGetSignerByFiscalCode } from "../../__mocks__/signer";
 
+import { validate } from "@internal/io-sign/validation";
+import { error, success } from "@internal/io-sign/infra/http/response";
+
 const makeGetSignerByFiscalCodeHandler = () => {
   const requireFiscalCode: RE.ReaderEither<HttpRequest, Error, FiscalCode> =
     flow(
-      body(GetSignerByFiscalCodeBody),
+      (req) => req.body,
+      validate(GetSignerByFiscalCodeBody),
       E.map((body) => body.fiscal_code),
       E.chain(validate(FiscalCode, "not a valid fiscal code"))
     );

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/get-upload-url.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/get-upload-url.ts
@@ -5,14 +5,8 @@ import * as RTE from "fp-ts/lib/ReaderTaskEither";
 import * as azure from "@pagopa/handler-kit/lib/azure";
 
 import { flow, identity, pipe } from "fp-ts/lib/function";
-import {
-  error,
-  HttpRequest,
-  path,
-  success,
-} from "@pagopa/handler-kit/lib/http";
+import { HttpRequest, path } from "@pagopa/handler-kit/lib/http";
 import { sequenceS } from "fp-ts/lib/Apply";
-import { validate } from "@pagopa/handler-kit/lib/validation";
 import { Document } from "@internal/io-sign/document";
 import { createHandler } from "@pagopa/handler-kit";
 import { CosmosClient, Database as CosmosDatabase } from "@azure/cosmos";
@@ -31,6 +25,9 @@ import { UploadUrlToApiModel } from "../../http/encoders/upload";
 import { makeRequireSignatureRequest } from "../../http/decoders/signature-request";
 import { makeInsertUploadMetadata } from "../cosmos/upload";
 import { getConfigFromEnvironment } from "../../../app/config";
+
+import { validate } from "@internal/io-sign/validation";
+import { error, success } from "@internal/io-sign/infra/http/response";
 
 const makeGetUploadUrlHandler = (
   db: CosmosDatabase,

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/set-signature-request-status.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/set-signature-request-status.ts
@@ -5,7 +5,7 @@ import * as RE from "fp-ts/lib/ReaderEither";
 
 import * as azure from "@pagopa/handler-kit/lib/azure";
 import { flow, identity, pipe } from "fp-ts/lib/function";
-import { body, error, HttpRequest } from "@pagopa/handler-kit/lib/http";
+import { HttpRequest } from "@pagopa/handler-kit/lib/http";
 import { sequenceS } from "fp-ts/lib/Apply";
 
 import { createHandler } from "@pagopa/handler-kit";
@@ -22,6 +22,8 @@ import {
 
 import { mockGetIssuerBySubscriptionId } from "../../__mocks__/issuer";
 import { getConfigFromEnvironment } from "../../../app/config";
+import { validate } from "@internal/io-sign/validation";
+import { error } from "@internal/io-sign/infra/http/response";
 
 const makeSetSignatureRequestStatusHandler = (db: CosmosDatabase) => {
   const upsertSignatureRequest = makeUpsertSignatureRequest(db);
@@ -39,7 +41,8 @@ const makeSetSignatureRequestStatusHandler = (db: CosmosDatabase) => {
     Error,
     "READY"
   > = flow(
-    body(SetSignatureRequestStatusBody),
+    (req) => req.body,
+    validate(SetSignatureRequestStatusBody),
     E.filterOrElse(
       (status) => status === "READY",
       () => new Error("only READY is allowed")

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/validate-upload.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/validate-upload.ts
@@ -8,7 +8,7 @@ import * as azure from "@pagopa/handler-kit/lib/azure";
 
 import { last } from "fp-ts/ReadonlyNonEmptyArray";
 import { split } from "fp-ts/string";
-import { validate } from "@pagopa/handler-kit/lib/validation";
+
 import { CosmosClient, Database as CosmosDatabase } from "@azure/cosmos";
 import { ContainerClient } from "@azure/storage-blob";
 import { createHandler } from "@pagopa/handler-kit";
@@ -31,6 +31,8 @@ import {
   UploadMetadata,
   uploadMetadataNotFoundError,
 } from "../../../upload";
+
+import { validate } from "@internal/io-sign/validation";
 
 export const extractFileNameFromURI = flow(split("/"), last);
 

--- a/apps/io-func-sign-issuer/src/infra/azure/storage/upload.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/storage/upload.ts
@@ -11,7 +11,9 @@ import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/function";
 
 import { addMinutes } from "date-fns";
-import { validate } from "@pagopa/handler-kit/lib/validation";
+
+import { validate } from "@internal/io-sign/validation";
+
 import {
   DeleteUploadMetadata,
   GetUploadUrl,

--- a/apps/io-func-sign-issuer/src/infra/http/decoders/document.ts
+++ b/apps/io-func-sign-issuer/src/infra/http/decoders/document.ts
@@ -1,5 +1,6 @@
-import { body } from "@pagopa/handler-kit/lib/http";
-import { validate } from "@pagopa/handler-kit/lib/validation";
+import { validate } from "@internal/io-sign/validation";
+
+import { HttpRequest } from "@pagopa/handler-kit/lib/http";
 
 import { flow, pipe } from "fp-ts/lib/function";
 
@@ -80,7 +81,8 @@ export const DocumentMetadataFromApiModel = new t.Type<
 );
 
 export const requireDocumentsMetadata = flow(
-  body(CreateDossierBody),
+  (res: HttpRequest) => res.body,
+  validate(CreateDossierBody),
   E.map((body) => body.documents_metadata),
   E.chain(
     validate(

--- a/apps/io-func-sign-issuer/src/infra/http/decoders/issuer.ts
+++ b/apps/io-func-sign-issuer/src/infra/http/decoders/issuer.ts
@@ -1,5 +1,6 @@
 import { header, HttpRequest } from "@pagopa/handler-kit/lib/http";
-import { validate } from "@pagopa/handler-kit/lib/validation";
+
+import { validate } from "@internal/io-sign/validation";
 
 import { pipe, flow } from "fp-ts/lib/function";
 

--- a/apps/io-func-sign-issuer/src/signature-request.ts
+++ b/apps/io-func-sign-issuer/src/signature-request.ts
@@ -13,6 +13,8 @@ import { addDays, isBefore } from "date-fns/fp";
 
 import { IsoDateFromString } from "@pagopa/ts-commons/lib/dates";
 
+import { ActionNotAllowedError } from "@internal/io-sign/error";
+
 import {
   Document,
   startValidation,
@@ -116,13 +118,6 @@ export const replaceDocument =
 export const canBeMarkedAsReady = (request: SignatureRequest) =>
   request.status === "DRAFT" &&
   request.documents.every((document) => document.status === "READY");
-
-export class ActionNotAllowedError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "ActionNotAllowedError";
-  }
-}
 
 type Action_MARK_AS_READY = {
   name: "MARK_AS_READY";
@@ -332,7 +327,3 @@ export type InsertSignatureRequest = (
 export type UpsertSignatureRequest = (
   request: SignatureRequest
 ) => TE.TaskEither<Error, SignatureRequest>;
-
-export const signatureRequestNotFoundError = new EntityNotFoundError(
-  "SignatureRequest"
-);

--- a/apps/io-func-sign-issuer/src/signature-request.ts
+++ b/apps/io-func-sign-issuer/src/signature-request.ts
@@ -71,8 +71,9 @@ export const newSignatureRequest = (
 });
 
 class InvalidExpiryDateError extends Error {
+  name = "InvalidExpireDateError";
   constructor() {
-    super("... invalid expiry date");
+    super("Invalid expiry date provided");
   }
 }
 

--- a/apps/io-func-sign-user/package.json
+++ b/apps/io-func-sign-user/package.json
@@ -18,7 +18,7 @@
     "@azure/storage-queue": "^12.11.0",
     "@internal/io-sign": "*",
     "@internal/pdv-tokenizer": "*",
-    "@pagopa/handler-kit": "^0.3.3",
+    "@pagopa/handler-kit": "^0.4.2",
     "@pagopa/ts-commons": "^10.10.0",
     "date-fns": "^2.29.3",
     "fp-ts": "^2.13.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@azure/storage-queue": "^12.11.0",
         "@internal/io-sign": "*",
         "@internal/pdv-tokenizer": "*",
-        "@pagopa/handler-kit": "^0.3.3",
+        "@pagopa/handler-kit": "^0.4.2",
         "@pagopa/ts-commons": "^10.10.0",
         "date-fns": "^2.29.3",
         "fp-ts": "^2.13.1",
@@ -71,7 +71,7 @@
         "@azure/storage-queue": "^12.11.0",
         "@internal/io-sign": "*",
         "@internal/pdv-tokenizer": "*",
-        "@pagopa/handler-kit": "^0.3.3",
+        "@pagopa/handler-kit": "^0.4.2",
         "@pagopa/ts-commons": "^10.10.0",
         "date-fns": "^2.29.3",
         "fp-ts": "^2.13.1",
@@ -467,6 +467,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -601,6 +607,40 @@
       "resolved": "packages/pdv-tokenizer",
       "link": true
     },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
     "node_modules/@jsdevtools/ono": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
@@ -673,12 +713,12 @@
       }
     },
     "node_modules/@pagopa/handler-kit": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@pagopa/handler-kit/-/handler-kit-0.3.3.tgz",
-      "integrity": "sha512-/OT75/R7w9xarjSXDPN52kHl9IGFnS1tdHeNCBfbwe29+ha8sBwNmEMjkYu0D5ZLC0qVSXHXN9oq87jqWb21JQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@pagopa/handler-kit/-/handler-kit-0.4.2.tgz",
+      "integrity": "sha512-d2bXBIgD+rGj3MCCLDqJc7a2GoSiEcBseAc2/AlAOqoWnV4Hh+jw90W7ksMJnWS5mNW6WljHLAnNguSZl0SNgA==",
       "dependencies": {
-        "fp-ts": "^2.12.1",
-        "io-ts": "^2.2.16"
+        "fp-ts": "^2.13.1",
+        "io-ts": "^2.2.19"
       }
     },
     "node_modules/@pagopa/io-functions-commons": {
@@ -1039,6 +1079,12 @@
         "@types/chai": "*"
       }
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+      "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
+      "dev": true
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -1309,6 +1355,83 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vitest/coverage-c8": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.25.2.tgz",
+      "integrity": "sha512-qKsiUJh3bjbB5Q229CbxEWCqiDBwvIrcZ9OOuQdMEC0pce3/LlTUK3+K3hd7WqAYEbbiqXfC5MVMKHZkV82PgA==",
+      "dev": true,
+      "dependencies": {
+        "c8": "^7.12.0",
+        "vitest": "0.25.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vitest/coverage-c8/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@vitest/coverage-c8/node_modules/vitest": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.25.2.tgz",
+      "integrity": "sha512-qqkzfzglEFbQY7IGkgSJkdOhoqHjwAao/OrphnHboeYHC5JzsVFoLCaB2lnAy8krhj7sbrFTVRApzpkTOeuDWQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^4.3.3",
+        "@types/chai-subset": "^1.3.3",
+        "@types/node": "*",
+        "acorn": "^8.8.0",
+        "acorn-walk": "^8.2.0",
+        "chai": "^4.3.6",
+        "debug": "^4.3.4",
+        "local-pkg": "^0.4.2",
+        "source-map": "^0.6.1",
+        "strip-literal": "^0.4.2",
+        "tinybench": "^2.3.1",
+        "tinypool": "^0.3.0",
+        "tinyspy": "^1.0.2",
+        "vite": "^3.0.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": ">=v14.16.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@vitest/browser": "*",
+        "@vitest/ui": "*",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/ui": {
       "version": "0.24.5",
       "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-0.24.5.tgz",
@@ -1370,6 +1493,15 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -2288,6 +2420,32 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/c8": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-7.12.0.tgz",
+      "integrity": "sha512-CtgQrHOkyxr5koX1wEUmN/5cfDa2ckbHRA4Gy5LAL0zaCFtVWJS5++n+w4/sr2GWGerBxgTjpKeDclk/Qk6W/A==",
+      "dev": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@istanbuljs/schema": "^0.1.3",
+        "find-up": "^5.0.0",
+        "foreground-child": "^2.0.0",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-reports": "^3.1.4",
+        "rimraf": "^3.0.2",
+        "test-exclude": "^6.0.0",
+        "v8-to-istanbul": "^9.0.0",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9"
+      },
+      "bin": {
+        "c8": "bin/c8.js"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -2487,6 +2645,17 @@
         "ip6addr": "^0.2.2"
       }
     },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
     "node_modules/cls-hooked": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
@@ -2672,6 +2841,12 @@
         "async-listener": "^0.6.0",
         "emitter-listener": "^1.1.1"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
     },
     "node_modules/cookie": {
       "version": "0.5.0",
@@ -3383,6 +3558,15 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -4255,6 +4439,19 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "dev": true
     },
+    "node_modules/foreground-child": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -4705,6 +4902,12 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
     },
     "node_modules/html-void-elements": {
       "version": "1.0.5",
@@ -5292,6 +5495,42 @@
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
       "dev": true
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
+      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -5588,6 +5827,30 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/markdown-escapes": {
@@ -7454,6 +7717,20 @@
         "node": ">=10"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -8155,6 +8432,20 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
+      "integrity": "sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/validator": {
       "version": "13.7.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
@@ -8454,6 +8745,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -8512,6 +8820,15 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -8525,6 +8842,33 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/yocto-queue": {
@@ -8595,6 +8939,8 @@
       },
       "devDependencies": {
         "@pagopa/eslint-config": "^3.0.0",
+        "@pagopa/handler-kit": "^0.4.2",
+        "@vitest/coverage-c8": "^0.25.2",
         "eslint": "^8.26.0",
         "prettier": "^2.7.1",
         "typescript": "^4.8.4",
@@ -8956,6 +9302,12 @@
         }
       }
     },
+    "@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
     "@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -9057,7 +9409,9 @@
       "version": "file:packages/io-sign",
       "requires": {
         "@pagopa/eslint-config": "^3.0.0",
+        "@pagopa/handler-kit": "^0.4.2",
         "@pagopa/ts-commons": "^10.10.0",
+        "@vitest/coverage-c8": "^0.25.2",
         "eslint": "^8.26.0",
         "fp-ts": "^2.13.1",
         "io-ts": "^2.2.19",
@@ -9081,6 +9435,34 @@
         "prettier": "^2.7.1",
         "typescript": "^4.8.4",
         "vitest": "^0.24.5"
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
     "@jsdevtools/ono": {
@@ -9143,12 +9525,12 @@
       }
     },
     "@pagopa/handler-kit": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@pagopa/handler-kit/-/handler-kit-0.3.3.tgz",
-      "integrity": "sha512-/OT75/R7w9xarjSXDPN52kHl9IGFnS1tdHeNCBfbwe29+ha8sBwNmEMjkYu0D5ZLC0qVSXHXN9oq87jqWb21JQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@pagopa/handler-kit/-/handler-kit-0.4.2.tgz",
+      "integrity": "sha512-d2bXBIgD+rGj3MCCLDqJc7a2GoSiEcBseAc2/AlAOqoWnV4Hh+jw90W7ksMJnWS5mNW6WljHLAnNguSZl0SNgA==",
       "requires": {
-        "fp-ts": "^2.12.1",
-        "io-ts": "^2.2.16"
+        "fp-ts": "^2.13.1",
+        "io-ts": "^2.2.19"
       }
     },
     "@pagopa/io-functions-commons": {
@@ -9447,6 +9829,12 @@
         "@types/chai": "*"
       }
     },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+      "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -9626,6 +10014,46 @@
         "eslint-visitor-keys": "^3.3.0"
       }
     },
+    "@vitest/coverage-c8": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.25.2.tgz",
+      "integrity": "sha512-qKsiUJh3bjbB5Q229CbxEWCqiDBwvIrcZ9OOuQdMEC0pce3/LlTUK3+K3hd7WqAYEbbiqXfC5MVMKHZkV82PgA==",
+      "dev": true,
+      "requires": {
+        "c8": "^7.12.0",
+        "vitest": "0.25.2"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "vitest": {
+          "version": "0.25.2",
+          "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.25.2.tgz",
+          "integrity": "sha512-qqkzfzglEFbQY7IGkgSJkdOhoqHjwAao/OrphnHboeYHC5JzsVFoLCaB2lnAy8krhj7sbrFTVRApzpkTOeuDWQ==",
+          "dev": true,
+          "requires": {
+            "@types/chai": "^4.3.3",
+            "@types/chai-subset": "^1.3.3",
+            "@types/node": "*",
+            "acorn": "^8.8.0",
+            "acorn-walk": "^8.2.0",
+            "chai": "^4.3.6",
+            "debug": "^4.3.4",
+            "local-pkg": "^0.4.2",
+            "source-map": "^0.6.1",
+            "strip-literal": "^0.4.2",
+            "tinybench": "^2.3.1",
+            "tinypool": "^0.3.0",
+            "tinyspy": "^1.0.2",
+            "vite": "^3.0.0"
+          }
+        }
+      }
+    },
     "@vitest/ui": {
       "version": "0.24.5",
       "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-0.24.5.tgz",
@@ -9674,6 +10102,12 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
     },
     "agent-base": {
       "version": "6.0.2",
@@ -10420,6 +10854,26 @@
       "dev": true,
       "peer": true
     },
+    "c8": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-7.12.0.tgz",
+      "integrity": "sha512-CtgQrHOkyxr5koX1wEUmN/5cfDa2ckbHRA4Gy5LAL0zaCFtVWJS5++n+w4/sr2GWGerBxgTjpKeDclk/Qk6W/A==",
+      "dev": true,
+      "requires": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@istanbuljs/schema": "^0.1.3",
+        "find-up": "^5.0.0",
+        "foreground-child": "^2.0.0",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-reports": "^3.1.4",
+        "rimraf": "^3.0.2",
+        "test-exclude": "^6.0.0",
+        "v8-to-istanbul": "^9.0.0",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9"
+      }
+    },
     "cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -10561,6 +11015,17 @@
       "dev": true,
       "requires": {
         "ip6addr": "^0.2.2"
+      }
+    },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
       }
     },
     "cls-hooked": {
@@ -10717,6 +11182,12 @@
         "async-listener": "^0.6.0",
         "emitter-listener": "^1.1.1"
       }
+    },
+    "convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
     },
     "cookie": {
       "version": "0.5.0",
@@ -11159,6 +11630,12 @@
       "integrity": "sha512-Of3MIacva1OK/m4zCNIvBfz8VVROBmQT+gRX6pFTLPngFYcj6TFH/12VveAqq1k9VB2l28EoVMNMUCcmsfwyuA==",
       "dev": true,
       "optional": true
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -11837,6 +12314,16 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "dev": true
     },
+    "foreground-child": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -12166,6 +12653,12 @@
         "dasherize": "2.0.0"
       }
     },
+    "html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
     "html-void-elements": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.5.tgz",
@@ -12322,7 +12815,7 @@
         "@internal/io-sign": "*",
         "@internal/pdv-tokenizer": "*",
         "@pagopa/eslint-config": "^3.0.0",
-        "@pagopa/handler-kit": "^0.3.3",
+        "@pagopa/handler-kit": "^0.4.2",
         "@pagopa/io-functions-commons": "^25.9.1",
         "@pagopa/openapi-codegen-ts": "^12.0.1",
         "@pagopa/ts-commons": "^10.10.0",
@@ -12349,7 +12842,7 @@
         "@internal/io-sign": "*",
         "@internal/pdv-tokenizer": "*",
         "@pagopa/eslint-config": "^3.0.0",
-        "@pagopa/handler-kit": "^0.3.3",
+        "@pagopa/handler-kit": "^0.4.2",
         "@pagopa/io-functions-commons": "^25.9.1",
         "@pagopa/openapi-codegen-ts": "^12.0.1",
         "@pagopa/ts-commons": "^10.10.0",
@@ -12623,6 +13116,33 @@
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
       "dev": true
     },
+    "istanbul-lib-coverage": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+      "dev": true
+    },
+    "istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "istanbul-reports": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
+      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
+      "dev": true,
+      "requires": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      }
+    },
     "joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -12871,6 +13391,23 @@
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
+      }
+    },
+    "make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "requires": {
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "markdown-escapes": {
@@ -14265,6 +14802,17 @@
         "@apidevtools/swagger-parser": "10.0.3"
       }
     },
+    "test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      }
+    },
     "text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -14780,6 +15328,17 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
+    "v8-to-istanbul": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
+      "integrity": "sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^1.6.0"
+      }
+    },
     "validator": {
       "version": "13.7.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
@@ -14975,6 +15534,17 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -15026,6 +15596,12 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -15036,6 +15612,27 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true
     },
     "yocto-queue": {

--- a/packages/io-sign/.prettierignore
+++ b/packages/io-sign/.prettierignore
@@ -1,0 +1,2 @@
+dist
+coverage

--- a/packages/io-sign/package.json
+++ b/packages/io-sign/package.json
@@ -22,13 +22,15 @@
   },
   "devDependencies": {
     "@pagopa/eslint-config": "^3.0.0",
+    "@vitest/coverage-c8": "^0.25.2",
+    "@pagopa/handler-kit": "^0.4.2",
     "eslint": "^8.26.0",
     "prettier": "^2.7.1",
     "typescript": "^4.8.4",
     "vitest": "^0.24.5"
   },
   "scripts": {
-    "test": "vitest run",
+    "test": "vitest run --coverage",
     "typecheck": "tsc",
     "format": "prettier --write .",
     "lint": "eslint src/**",

--- a/packages/io-sign/src/document.ts
+++ b/packages/io-sign/src/document.ts
@@ -11,6 +11,8 @@ import {
 
 import { IsoDateFromString } from "@pagopa/ts-commons/lib/dates";
 
+import { ActionNotAllowedError } from "./error";
+
 import { NonNegativeNumber } from "@pagopa/ts-commons/lib/numbers";
 
 import { pipe } from "fp-ts/lib/function";
@@ -120,13 +122,6 @@ export const newDocument = (metadata: DocumentMetadata): Document => ({
   createdAt: new Date(),
   updatedAt: new Date(),
 });
-
-export class ActionNotAllowedError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "ActionNotAllowedError";
-  }
-}
 
 type Action_START_VALIDATION = {
   name: "START_VALIDATION";

--- a/packages/io-sign/src/error.ts
+++ b/packages/io-sign/src/error.ts
@@ -1,6 +1,7 @@
 export class EntityNotFoundError extends Error {
-  constructor(entityName: string) {
-    super(`${entityName} not found`);
-    this.name = "EntityNotFoundError";
-  }
+  name = "EntityNotFoundError";
+}
+
+export class ActionNotAllowedError extends Error {
+  name = "ActionNotAllowedError";
 }

--- a/packages/io-sign/src/infra/http/__test__/errors.spec.ts
+++ b/packages/io-sign/src/infra/http/__test__/errors.spec.ts
@@ -69,6 +69,26 @@ describe.concurrent("errors", () => {
       );
       expect(isHttpBadRequest).toBe(true);
     });
+    it("should parse an InvalidExpiryDateError as HttpBadRequest", () => {
+      const invalidExpiryDateError = new (class extends Error {
+        name = "InvalidExpiryDateError";
+      })("Action not allowed");
+      const isHttpBadRequest = pipe(
+        HttpErrorFromError.decode(invalidExpiryDateError),
+        E.mapLeft(() => false),
+        E.filterOrElse(
+          (e) => e.name === "HttpError",
+          () => false
+        ),
+        E.filterOrElse(
+          (e) => e.status === 400,
+          () => false
+        ),
+        E.map(HttpErrorFromError.is),
+        E.getOrElse(identity)
+      );
+      expect(isHttpBadRequest).toBe(true);
+    });
     it("should fail on unsupported error type", () => {
       const unexpected = new Error("Unexpected.");
       const unsupported = pipe(HttpErrorFromError.decode(unexpected), E.isLeft);

--- a/packages/io-sign/src/infra/http/__test__/errors.spec.ts
+++ b/packages/io-sign/src/infra/http/__test__/errors.spec.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  HttpBadRequestError,
+  HttpError,
+  HttpErrorFromError,
+  HttpNotFoundError,
+} from "../errors";
+import * as E from "fp-ts/lib/Either";
+import { identity, pipe } from "fp-ts/lib/function";
+import { ActionNotAllowedError, EntityNotFoundError } from "../../../error";
+
+describe.concurrent("errors", () => {
+  describe("isHttpError", () => {
+    it("should pass on a well-formed http error", () => {
+      const error = new HttpError("I'm an error, but at least I'm well-formed");
+      const plain = new Error("plain error");
+      expect(HttpErrorFromError.is(error)).toBe(true);
+      expect(HttpErrorFromError.is(plain)).toBe(false);
+      expect(HttpErrorFromError.is({})).toBe(false);
+      expect(HttpErrorFromError.is({ name: "HttpError" })).toBe(false);
+    });
+  });
+  describe("HttpErrorFromError", () => {
+    it("should pass when it's already an HttpError", () => {
+      const error = new HttpError("Already an HttpError.");
+      const isEqual = pipe(
+        HttpErrorFromError.decode(error),
+        E.map((e) => e === error),
+        E.getOrElse(() => false)
+      );
+      expect(isEqual).toBe(true);
+    });
+    it("should parse an EntityNotFoundError as HttpNotFoundError", () => {
+      const entityNotFound = new EntityNotFoundError(
+        "The specified entity was not found"
+      );
+      const isHttpNotFoundError = pipe(
+        HttpErrorFromError.decode(entityNotFound),
+        E.mapLeft(() => false),
+        E.filterOrElse(
+          (e) => e.name === "HttpError",
+          () => false
+        ),
+        E.filterOrElse(
+          (e) => e.status === 404,
+          () => false
+        ),
+        E.map(HttpErrorFromError.is),
+        E.getOrElse(identity)
+      );
+      expect(isHttpNotFoundError).toBe(true);
+    });
+    it("should parse an ActionNotAllowedError as HttpBadRequest", () => {
+      const actionNotAllowed = new ActionNotAllowedError("Action not allowed");
+      const isHttpBadRequest = pipe(
+        HttpErrorFromError.decode(actionNotAllowed),
+        E.mapLeft(() => false),
+        E.filterOrElse(
+          (e) => e.name === "HttpError",
+          () => false
+        ),
+        E.filterOrElse(
+          (e) => e.status === 400,
+          () => false
+        ),
+        E.map(HttpErrorFromError.is),
+        E.getOrElse(identity)
+      );
+      expect(isHttpBadRequest).toBe(true);
+    });
+    it("should fail on unsupported error type", () => {
+      const unexpected = new Error("Unexpected.");
+      const unsupported = pipe(HttpErrorFromError.decode(unexpected), E.isLeft);
+      expect(unsupported).toBe(true);
+    });
+  });
+  describe("HttpNotFoundError", () => {
+    it("has the 404 status code", () => {
+      const e = new HttpNotFoundError();
+      expect(e.status).toBe(404);
+    });
+  });
+  describe("HttpBadRequestError", () => {
+    it("has the 400 status code", () => {
+      const e = new HttpBadRequestError();
+      expect(e.status).toBe(400);
+    });
+  });
+});

--- a/packages/io-sign/src/infra/http/__test__/problem-detail.spec.ts
+++ b/packages/io-sign/src/infra/http/__test__/problem-detail.spec.ts
@@ -1,0 +1,27 @@
+import { flow, identity } from "fp-ts/lib/function";
+import { describe, it, expect } from "vitest";
+import { ActionNotAllowedError } from "../../../error";
+import { ValidationError } from "../../../validation";
+import { HttpError } from "../errors";
+import { ProblemDetail, toProblemDetail } from "../problem-detail";
+
+describe("problem-detail", () => {
+  describe("toProblemDetail", () => {
+    it("should parse a ValidationError as ValidationProblemDetail", () => {
+      const e = new ValidationError([]);
+      const problem = toProblemDetail(e);
+      expect(ProblemDetail.types[1].is(problem)).toBe(true);
+    });
+    it("should parse other errors as HttpProblemDetail", () => {
+      const errors = [
+        new HttpError(),
+        new ActionNotAllowedError(),
+        new Error("I'm a teapot!"),
+      ];
+      const result = errors
+        .map(flow(toProblemDetail, ProblemDetail.types[0].is))
+        .every(identity);
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/packages/io-sign/src/infra/http/__test__/response.spec.ts
+++ b/packages/io-sign/src/infra/http/__test__/response.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { success, created, error } from "../response";
+
+import * as t from "io-ts";
+
+describe.concurrent("response", () => {
+  describe("success", () => {
+    it("should create a response with 200 as status code", () => {
+      const res = success(t.string)("Success!");
+      expect(res.statusCode).toBe(200);
+    });
+    it("should serialize the payload as JSON", () => {
+      const payloadT = t.type({ message: t.string });
+      const payload: t.TypeOf<typeof payloadT> = { message: "It works!" };
+      const res = success(payloadT)(payload);
+      expect(res.body).toBe(JSON.stringify(payload));
+      expect(res.headers).toHaveProperty("Content-Type", "application/json");
+    });
+    it("should return a serialization error on invalid payload", () => {
+      const payload = { message: "It should not parse" };
+      const res = success(t.string)(payload);
+      expect(res.statusCode).toBe(500);
+      expect(res.headers).toHaveProperty(
+        "Content-Type",
+        "application/problem+json"
+      );
+    });
+  });
+  describe("created", () => {
+    it("should create a response with 201 as status code", () => {
+      const res = created(t.string)("Created");
+      expect(res.statusCode).toBe(201);
+    });
+  });
+  describe("error", () => {
+    it('should create a response with "application/problem+json" Content-Type', () => {
+      const res = error(new Error("Unexpected"));
+      expect(res.headers).toHaveProperty(
+        "Content-Type",
+        "application/problem+json"
+      );
+    });
+  });
+});

--- a/packages/io-sign/src/infra/http/errors.ts
+++ b/packages/io-sign/src/infra/http/errors.ts
@@ -36,6 +36,8 @@ export const HttpErrorFromError = new t.Type<HttpError, Error, Error>(
         return t.success(new HttpNotFoundError(e.message));
       case "ActionNotAllowedError":
         return t.success(new HttpBadRequestError(e.message));
+      case "InvalidExpiryDateError":
+        return t.success(new HttpBadRequestError(e.message));
     }
     return t.failure(e, ctx, "Unsupported error type.");
   },

--- a/packages/io-sign/src/infra/http/errors.ts
+++ b/packages/io-sign/src/infra/http/errors.ts
@@ -1,0 +1,43 @@
+import { identity } from "fp-ts/lib/function";
+
+import * as t from "io-ts";
+
+export class HttpError extends Error {
+  name = "HttpError";
+  status = 500;
+  title = "Internal Server Error";
+}
+
+const isHttpError = (u: unknown): u is HttpError =>
+  u instanceof HttpError &&
+  u.name === "HttpError" &&
+  typeof u.status === "number" &&
+  Number.isInteger(u.status);
+
+export class HttpNotFoundError extends HttpError {
+  status = 404;
+  title = "Not Found";
+}
+
+export class HttpBadRequestError extends HttpError {
+  status = 400;
+  title = "Bad Request";
+}
+
+export const HttpErrorFromError = new t.Type<HttpError, Error, Error>(
+  "HttpErrorFromError",
+  isHttpError,
+  (e, ctx) => {
+    if (isHttpError(e)) {
+      return t.success(e);
+    }
+    switch (e.name) {
+      case "EntityNotFoundError":
+        return t.success(new HttpNotFoundError(e.message));
+      case "ActionNotAllowedError":
+        return t.success(new HttpBadRequestError(e.message));
+    }
+    return t.failure(e, ctx, "Unsupported error type.");
+  },
+  identity
+);

--- a/packages/io-sign/src/infra/http/problem-detail.ts
+++ b/packages/io-sign/src/infra/http/problem-detail.ts
@@ -45,7 +45,7 @@ export const toProblemDetail = (e: Error): ProblemDetail => {
     };
   }
   return {
-    title: "Unexpected.",
+    title: "Something went wrong.",
     status: 500,
   };
 };

--- a/packages/io-sign/src/infra/http/problem-detail.ts
+++ b/packages/io-sign/src/infra/http/problem-detail.ts
@@ -1,0 +1,51 @@
+import * as t from "io-ts";
+import { ValidationError } from "../../validation";
+import { HttpError } from "./errors";
+
+const HttpProblemDetail = t.intersection([
+  t.type({
+    title: t.string,
+    status: t.number,
+  }),
+  t.partial({
+    detail: t.string,
+  }),
+]);
+
+const ValidationProblemDetail = t.type({
+  type: t.literal("/problems/validation-error"),
+  title: t.string,
+  detail: t.string,
+  status: t.literal(422),
+  violations: t.array(t.string),
+});
+
+export const ProblemDetail = t.union([
+  HttpProblemDetail,
+  ValidationProblemDetail,
+]);
+
+export type ProblemDetail = t.TypeOf<typeof ProblemDetail>;
+
+export const toProblemDetail = (e: Error): ProblemDetail => {
+  if (e instanceof ValidationError) {
+    return {
+      type: "/problems/validation-error",
+      title: e.title,
+      detail: e.message,
+      violations: e.violations,
+      status: 422,
+    };
+  }
+  if (e instanceof HttpError) {
+    return {
+      title: e.title,
+      status: e.status,
+      detail: e.message,
+    };
+  }
+  return {
+    title: "Unexpected.",
+    status: 500,
+  };
+};

--- a/packages/io-sign/src/infra/http/response.ts
+++ b/packages/io-sign/src/infra/http/response.ts
@@ -42,9 +42,11 @@ export const error = (e: Error) =>
   pipe(
     HttpErrorFromError.decode(e),
     E.orElse(() => E.right(e)),
-    E.map(toProblemDetail),
-    E.map((problem) => response(problem)),
-    E.map((res) => pipe(res, withStatusCode(res.body.status))),
+    E.map(
+      flow(toProblemDetail, response, (res) =>
+        pipe(res, withStatusCode(res.body.status))
+      )
+    ),
     E.chainW(serializeToJSON),
     E.map(withHeader("Content-Type", "application/problem+json")),
     E.getOrElse(() => serializationProblem)

--- a/packages/io-sign/src/infra/http/response.ts
+++ b/packages/io-sign/src/infra/http/response.ts
@@ -1,0 +1,51 @@
+import {
+  response,
+  withStatusCode,
+  withHeader,
+  serializeToJSON,
+} from "@pagopa/handler-kit/lib/http";
+
+import { validate } from "../../validation";
+
+import { pipe, flow } from "fp-ts/lib/function";
+import * as E from "fp-ts/lib/Either";
+
+import * as t from "io-ts";
+
+import { HttpError, HttpErrorFromError } from "./errors";
+
+import { toProblemDetail } from "./problem-detail";
+
+const serializationProblem = pipe(
+  new HttpError("Unable to serialize the response."),
+  toProblemDetail,
+  JSON.stringify,
+  response,
+  withStatusCode(500),
+  withHeader("Content-Type", "application/problem+json")
+);
+
+const jsonResponse =
+  (statusCode: number) =>
+  <T>(schema: t.Decoder<unknown, T>) =>
+    flow(
+      validate(schema, "Unable to validate the success response."),
+      E.map(flow(response, withStatusCode(statusCode))),
+      E.chainW(serializeToJSON),
+      E.getOrElse(() => serializationProblem)
+    );
+
+export const success = jsonResponse(200);
+export const created = jsonResponse(201);
+
+export const error = (e: Error) =>
+  pipe(
+    HttpErrorFromError.decode(e),
+    E.orElse(() => E.right(e)),
+    E.map(toProblemDetail),
+    E.map((problem) => response(problem)),
+    E.map((res) => pipe(res, withStatusCode(res.body.status))),
+    E.chainW(serializeToJSON),
+    E.map(withHeader("Content-Type", "application/problem+json")),
+    E.getOrElse(() => serializationProblem)
+  );

--- a/packages/io-sign/src/validation.ts
+++ b/packages/io-sign/src/validation.ts
@@ -1,0 +1,24 @@
+import * as t from "io-ts";
+import { failure } from "io-ts/PathReporter";
+import * as E from "fp-ts/lib/Either";
+import { flow } from "fp-ts/lib/function";
+
+export class ValidationError extends Error {
+  name = "ValidationError";
+  title = "Validation Error";
+  violations: string[];
+  static defaultMessage = "Your request parameters didn't validate";
+  constructor(violations: string[], message = ValidationError.defaultMessage) {
+    super(message);
+    this.violations = violations;
+  }
+}
+
+export const validate = <T>(
+  schema: t.Decoder<unknown, T>,
+  message = ValidationError.defaultMessage
+) =>
+  flow(
+    schema.decode,
+    E.mapLeft((errors) => new ValidationError(failure(errors), message))
+  );


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. Errors have been streamlined, they are now implemented with classes that extend Error (and a custom name, and optionally properties) that can be mapped to HTTP response errors 
2. Update `@pagopa/handler-kit` to `0.4.2`
3. `validate` function and `ValidationError` have been moved into `@internal/io-sign` from `@pagopa/handler-kit`
4. HTTP response constructors (`success`, `created`, `error`) are now part of `@internal/io-sign/infra/http` module 

<!--- Describe your changes in detail -->

#### Motivation and Context

The previous error handling system did not allow mapping domain errors to http errors.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

1. Due to the lack of e2e testing, the handlers were manually tested
2. All utility functions (inside `@internal/io-sign/infra/http`) have been unit tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

Example of `Validation Problem`

<img width="1154" alt="image" src="https://user-images.githubusercontent.com/4357400/201913020-a8c44865-4e5e-4779-a804-cc84a99a63b3.png">

Example of `Problem detail` with a simple HTTP error

<img width="993" alt="image" src="https://user-images.githubusercontent.com/4357400/201913238-44064fb4-4524-4876-b278-afc276e58745.png">

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.