### PR TITLE
core: integrate getProfile with tokenizer in getSigner

### DIFF
--- a/apps/io-func-sign-issuer/openapi.yaml
+++ b/apps/io-func-sign-issuer/openapi.yaml
@@ -250,9 +250,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/NotificationDetailView"
-        "409":
-          description: "If the notification has already been sent"
-          $ref: "#/components/responses/Conflict"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -309,13 +306,6 @@ components:
             $ref: "#/components/schemas/ProblemDetail"
 
     Unexpected:
-      description: Unexpected error
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ProblemDetail"
-
-    Conflict:
       description: Unexpected error
       content:
         application/json:

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/send-notification.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/send-notification.ts
@@ -13,8 +13,8 @@ import { CosmosClient, Database as CosmosDatabase } from "@azure/cosmos";
 import { makeSubmitMessageForUser } from "@internal/io-services/message";
 import { createIOApiClient, IOApiClient } from "@internal/io-services/client";
 import {
-  PdvTokenizerClient,
   createPdvTokenizerClient,
+  PdvTokenizerClientWithApiKey,
 } from "@internal/pdv-tokenizer/client";
 
 import { makeGetFiscalCodeBySignerId } from "@internal/pdv-tokenizer/signer";
@@ -39,7 +39,7 @@ import { makeGetDossier } from "../cosmos/dossier";
 const makeSendNotificationHandler = (
   db: CosmosDatabase,
   ioApiClient: IOApiClient,
-  tokenizer: PdvTokenizerClient
+  tokenizer: PdvTokenizerClientWithApiKey
 ) => {
   const getSignatureRequest = makeGetSignatureRequest(db);
   const upsertSignatureRequest = makeUpsertSignatureRequest(db);

--- a/packages/io-services/src/profile.ts
+++ b/packages/io-services/src/profile.ts
@@ -4,6 +4,7 @@ import * as E from "fp-ts/lib/Either";
 import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
 import { pipe, flow } from "fp-ts/lib/function";
 import {
+  ActionNotAllowedError,
   EntityNotFoundError,
   TooManyRequestsError,
 } from "@internal/io-sign/error";
@@ -35,6 +36,12 @@ export const makeRetriveUserProfileSenderAllowed =
               case 404:
                 return E.left(
                   new EntityNotFoundError(`User profile not found!`)
+                );
+              case 403:
+                return E.left(
+                  new ActionNotAllowedError(
+                    `You are not allowed to issue requests for this user!`
+                  )
                 );
               case 429:
                 return E.left(new TooManyRequestsError(`Too many requests!`));


### PR DESCRIPTION
This PR adds control over the user profile before returning a signerId. In this way, unauthorized users will be excluded.


#### How Has This Been Tested?
E2E manually tested

#### Types of changes
- [X] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
