### PR TITLE
chore: [SFEQS-1172] Add GitHub action to apply conventional labels

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,14 +19,7 @@
 
 #### Screenshots (if appropriate):
 
-#### Types of changes
-
-<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-
-- [ ] Chore (nothing changes by a user perspective)
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+<!--- Attach screenshots in case changes impact UI. -->
 
 #### Checklist:
 

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -7,7 +7,8 @@ changelog:
   categories:
     - title: Technical debt
       labels:
-        - technical-debt
+        - ci
+        - refactor
         - chore
         - test
     - title: Breaking changes
@@ -15,7 +16,7 @@ changelog:
         - breaking-change
     - title: New features
       labels:
-        - feature
+        - feat
     - title: Fixes
       labels:
         - fix

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,28 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+  categories:
+    - title: Technical debt
+      labels:
+        - technical-debt
+        - chore
+        - test
+    - title: Breaking changes
+      labels:
+        - breaking-change
+    - title: New features
+      labels:
+        - feature
+    - title: Fixes
+      labels:
+        - fix
+        - bug
+    - title: Documentation
+      labels:
+        - docs
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/conventional-labels.yaml
+++ b/.github/workflows/conventional-labels.yaml
@@ -1,0 +1,15 @@
+# Warning, do not check out untrusted code with
+# the pull_request_target event.
+on:
+  pull_request_target:
+    types: [opened, edited]
+name: conventional-release-labels
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      # npx pin-github-action .github/workflows/conventional-labels.yaml
+      - uses: bcoe/conventional-release-labels@886f696738527c7be444262c327c89436dfb95a8 # pin@v1
+        with:
+          type_labels: '{ "feat": "feature", "fix": "bug", "breaking": "breaking-change", "chore": "chore", "refactor": "technical-debt", "docs": "docs", "test": "test" }'
+          ignored_types: "[]"

--- a/.github/workflows/conventional-labels.yaml
+++ b/.github/workflows/conventional-labels.yaml
@@ -11,5 +11,5 @@ jobs:
       # npx pin-github-action .github/workflows/conventional-labels.yaml
       - uses: bcoe/conventional-release-labels@886f696738527c7be444262c327c89436dfb95a8 # pin@v1
         with:
-          type_labels: '{ "feat": "feature", "fix": "bug", "breaking": "breaking-change", "chore": "chore", "refactor": "technical-debt", "docs": "docs", "test": "test" }'
+          type_labels: '{ "feat": "feat", "fix": "fix", "breaking": "breaking-change", "chore": "chore", "refactor": "refactor", "docs": "docs", "test": "test" }'
           ignored_types: "[]"

--- a/TODO
+++ b/TODO
@@ -1,0 +1,3 @@
+- generate-api-models non è nel task della build
+
+- dove sono gli unit tests?

--- a/TODO
+++ b/TODO
@@ -1,3 +1,0 @@
-- generate-api-models non è nel task della build
-
-- dove sono gli unit tests?


### PR DESCRIPTION
#### List of Changes

Added GitHub workflow to automatically apply conventional labels on Pull Request.

#### Motivation and Context

This change let group Pull Requests by intent and generate nice GitHub release notes.
