### PR TITLE
fix: [SFEQS-1173] Make Azure clients singletons

### DIFF
--- a/apps/io-func-sign-issuer/src/app/config.ts
+++ b/apps/io-func-sign-issuer/src/app/config.ts
@@ -2,6 +2,7 @@ import * as t from "io-ts";
 
 import { pipe } from "fp-ts/function";
 import * as RE from "fp-ts/lib/ReaderEither";
+import * as E from "fp-ts/lib/Either";
 
 import { sequenceS } from "fp-ts/lib/Apply";
 import {
@@ -61,3 +62,11 @@ export const getConfigFromEnvironment: RE.ReaderEither<
     validatedStorageContainerName: "validated-documents",
   }))
 );
+
+export const getConfigOrThrow = (env: NodeJS.ProcessEnv = process.env) =>
+  pipe(
+    getConfigFromEnvironment(env),
+    E.getOrElseW((err) => {
+      throw err;
+    })
+  );

--- a/apps/io-func-sign-issuer/src/infra/api/io-services.ts
+++ b/apps/io-func-sign-issuer/src/infra/api/io-services.ts
@@ -1,0 +1,9 @@
+import { createIOApiClient } from "@internal/io-services/client";
+import { getConfigOrThrow } from "../../app/config";
+
+const config = getConfigOrThrow();
+
+export const ioApiClient = createIOApiClient(
+  config.pagopa.ioServices.basePath,
+  config.pagopa.ioServices.subscriptionKey
+);

--- a/apps/io-func-sign-issuer/src/infra/api/tokenizer.ts
+++ b/apps/io-func-sign-issuer/src/infra/api/tokenizer.ts
@@ -1,0 +1,9 @@
+import { createPdvTokenizerClient } from "@internal/pdv-tokenizer/client";
+import { getConfigOrThrow } from "../../app/config";
+
+const config = getConfigOrThrow();
+
+export const pdvTokenizerClientWithApiKey = createPdvTokenizerClient(
+  config.pagopa.tokenizer.basePath,
+  config.pagopa.tokenizer.apiKey
+);

--- a/apps/io-func-sign-issuer/src/infra/azure/cosmos/client.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/cosmos/client.ts
@@ -1,0 +1,7 @@
+import { CosmosClient } from "@azure/cosmos";
+import { getConfigOrThrow } from "../../../app/config";
+
+const config = getConfigOrThrow();
+
+const cosmosClient = new CosmosClient(config.azure.cosmos.connectionString);
+export const database = cosmosClient.database(config.azure.cosmos.dbName);

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/create-dossier.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/create-dossier.ts
@@ -1,11 +1,11 @@
-import { CosmosClient, Database as CosmosDatabase } from "@azure/cosmos";
+import { Database as CosmosDatabase } from "@azure/cosmos";
 
 import * as E from "fp-ts/lib/Either";
 import * as TE from "fp-ts/lib/TaskEither";
 import * as RTE from "fp-ts/lib/ReaderTaskEither";
 
 import { sequenceS } from "fp-ts/lib/Apply";
-import { flow, identity, pipe } from "fp-ts/lib/function";
+import { flow, pipe } from "fp-ts/lib/function";
 
 import { createHandler } from "@pagopa/handler-kit";
 import { HttpRequest } from "@pagopa/handler-kit/lib/http";
@@ -27,9 +27,9 @@ import { DossierToApiModel } from "../../http/encoders/dossier";
 
 import { makeInsertDossier } from "../cosmos/dossier";
 import { mockGetIssuerBySubscriptionId } from "../../__mocks__/issuer";
-import { getConfigFromEnvironment } from "../../../app/config";
 import { CreateDossierBody } from "../../http/models/CreateDossierBody";
 import { Dossier } from "../../../dossier";
+import { database } from "../cosmos/client";
 
 const makeCreateDossierHandler = (db: CosmosDatabase) => {
   const createDossierUseCase = pipe(db, makeInsertDossier, makeCreateDossier);
@@ -69,19 +69,5 @@ const makeCreateDossierHandler = (db: CosmosDatabase) => {
     encodeHttpResponse
   );
 };
-
-const configOrError = pipe(
-  getConfigFromEnvironment(process.env),
-  E.getOrElseW(identity)
-);
-
-if (configOrError instanceof Error) {
-  throw configOrError;
-}
-
-const config = configOrError;
-
-const cosmosClient = new CosmosClient(config.azure.cosmos.connectionString);
-const database = cosmosClient.database(config.azure.cosmos.dbName);
 
 export const run = pipe(makeCreateDossierHandler(database), azure.unsafeRun);

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/create-signature-request.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/create-signature-request.ts
@@ -9,10 +9,10 @@ import { validate } from "@internal/io-sign/validation";
 
 import { sequenceS } from "fp-ts/lib/Apply";
 
-import { pipe, flow, identity } from "fp-ts/lib/function";
+import { pipe, flow } from "fp-ts/lib/function";
 import * as azure from "@pagopa/handler-kit/lib/azure";
 import { createHandler } from "@pagopa/handler-kit";
-import { CosmosClient, Database as CosmosDatabase } from "@azure/cosmos";
+import { Database as CosmosDatabase } from "@azure/cosmos";
 import { created, error } from "@internal/io-sign/infra/http/response";
 import { EntityNotFoundError } from "@internal/io-sign/error";
 import { makeRequireIssuer } from "../../http/decoders/issuer";
@@ -31,7 +31,7 @@ import {
 import { makeInsertSignatureRequest } from "../cosmos/signature-request";
 import { mockGetSigner } from "../../__mocks__/signer";
 import { mockGetIssuerBySubscriptionId } from "../../__mocks__/issuer";
-import { getConfigFromEnvironment } from "../../../app/config";
+import { database } from "../cosmos/client";
 
 const makeCreateSignatureRequestHandler = (db: CosmosDatabase) => {
   const getDossier = makeGetDossier(db);
@@ -118,20 +118,6 @@ const makeCreateSignatureRequestHandler = (db: CosmosDatabase) => {
     encodeHttpSuccessResponse
   );
 };
-
-const configOrError = pipe(
-  getConfigFromEnvironment(process.env),
-  E.getOrElseW(identity)
-);
-
-if (configOrError instanceof Error) {
-  throw configOrError;
-}
-
-const config = configOrError;
-
-const cosmosClient = new CosmosClient(config.azure.cosmos.connectionString);
-const database = cosmosClient.database(config.azure.cosmos.dbName);
 
 export const run = pipe(
   makeCreateSignatureRequestHandler(database),

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/get-signature-request.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/get-signature-request.ts
@@ -1,20 +1,19 @@
-import { Database as CosmosDatabase, CosmosClient } from "@azure/cosmos";
+import { Database as CosmosDatabase } from "@azure/cosmos";
 
-import * as E from "fp-ts/lib/Either";
 import * as TE from "fp-ts/lib/TaskEither";
 
 import { error, success } from "@internal/io-sign/infra/http/response";
 
 import * as azure from "@pagopa/handler-kit/lib/azure";
 
-import { flow, identity, pipe } from "fp-ts/lib/function";
+import { flow, pipe } from "fp-ts/lib/function";
 import { createHandler } from "@pagopa/handler-kit";
 import { SignatureRequestToApiModel } from "../../http/encoders/signature-request";
 import { SignatureRequestDetailView } from "../../http/models/SignatureRequestDetailView";
 import { makeRequireSignatureRequest } from "../../http/decoders/signature-request";
 import { mockGetIssuerBySubscriptionId } from "../../__mocks__/issuer";
 import { makeGetSignatureRequest } from "../cosmos/signature-request";
-import { getConfigFromEnvironment } from "../../../app/config";
+import { database } from "../cosmos/client";
 
 const makeGetSignatureRequestHandler = (db: CosmosDatabase) => {
   const getSignatureRequest = makeGetSignatureRequest(db);
@@ -42,20 +41,6 @@ const makeGetSignatureRequestHandler = (db: CosmosDatabase) => {
     encodeHttpSuccessResponse
   );
 };
-
-const configOrError = pipe(
-  getConfigFromEnvironment(process.env),
-  E.getOrElseW(identity)
-);
-
-if (configOrError instanceof Error) {
-  throw configOrError;
-}
-
-const config = configOrError;
-
-const cosmosClient = new CosmosClient(config.azure.cosmos.connectionString);
-const database = cosmosClient.database(config.azure.cosmos.dbName);
 
 export const run = pipe(
   makeGetSignatureRequestHandler(database),

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/get-signer.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/get-signer.ts
@@ -5,14 +5,11 @@ import * as RE from "fp-ts/lib/ReaderEither";
 
 import * as E from "fp-ts/lib/Either";
 
-import { flow, identity, pipe } from "fp-ts/lib/function";
+import { flow, pipe } from "fp-ts/lib/function";
 
 import * as azure from "@pagopa/handler-kit/lib/azure";
 
-import {
-  createPdvTokenizerClient,
-  PdvTokenizerClientWithApiKey,
-} from "@internal/pdv-tokenizer/client";
+import { PdvTokenizerClientWithApiKey } from "@internal/pdv-tokenizer/client";
 import { makeGetSignerByFiscalCode } from "@internal/pdv-tokenizer/signer";
 
 import * as TE from "fp-ts/lib/TaskEither";
@@ -22,12 +19,13 @@ import { createHandler } from "@pagopa/handler-kit";
 import { validate } from "@internal/io-sign/validation";
 import { error, success } from "@internal/io-sign/infra/http/response";
 import { makeRetriveUserProfileSenderAllowed } from "@internal/io-services/profile";
-import { createIOApiClient, IOApiClient } from "@internal/io-services/client";
+import { IOApiClient } from "@internal/io-services/client";
 import { GetSignerByFiscalCodeBody } from "../../http/models/GetSignerByFiscalCodeBody";
 
 import { SignerToApiModel } from "../../http/encoders/signer";
 import { SignerDetailView } from "../../http/models/SignerDetailView";
-import { getConfigFromEnvironment } from "../../../app/config";
+import { ioApiClient } from "../../api/io-services";
+import { pdvTokenizerClientWithApiKey } from "../../api/tokenizer";
 
 const makeGetSignerByFiscalCodeHandler = (
   pdvTokenizerClientWithApiKey: PdvTokenizerClientWithApiKey,
@@ -73,27 +71,6 @@ const makeGetSignerByFiscalCodeHandler = (
     encodeHttpSuccessResponse
   );
 };
-
-const configOrError = pipe(
-  getConfigFromEnvironment(process.env),
-  E.getOrElseW(identity)
-);
-
-if (configOrError instanceof Error) {
-  throw configOrError;
-}
-
-const config = configOrError;
-
-const pdvTokenizerClientWithApiKey = createPdvTokenizerClient(
-  config.pagopa.tokenizer.basePath,
-  config.pagopa.tokenizer.apiKey
-);
-
-const ioApiClient = createIOApiClient(
-  config.pagopa.ioServices.basePath,
-  config.pagopa.ioServices.subscriptionKey
-);
 
 export const run = pipe(
   makeGetSignerByFiscalCodeHandler(pdvTokenizerClientWithApiKey, ioApiClient),

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/get-upload-url.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/get-upload-url.ts
@@ -4,12 +4,12 @@ import * as RTE from "fp-ts/lib/ReaderTaskEither";
 
 import * as azure from "@pagopa/handler-kit/lib/azure";
 
-import { flow, identity, pipe } from "fp-ts/lib/function";
+import { flow, pipe } from "fp-ts/lib/function";
 import { HttpRequest, path } from "@pagopa/handler-kit/lib/http";
 import { sequenceS } from "fp-ts/lib/Apply";
 import { Document } from "@internal/io-sign/document";
 import { createHandler } from "@pagopa/handler-kit";
-import { CosmosClient, Database as CosmosDatabase } from "@azure/cosmos";
+import { Database as CosmosDatabase } from "@azure/cosmos";
 import { ContainerClient } from "@azure/storage-blob";
 import { validate } from "@internal/io-sign/validation";
 import { error, success } from "@internal/io-sign/infra/http/response";
@@ -26,7 +26,8 @@ import {
 import { UploadUrlToApiModel } from "../../http/encoders/upload";
 import { makeRequireSignatureRequest } from "../../http/decoders/signature-request";
 import { makeInsertUploadMetadata } from "../cosmos/upload";
-import { getConfigFromEnvironment } from "../../../app/config";
+import { database } from "../cosmos/client";
+import { uploadedContainerClient } from "../storage/upload-container-client";
 
 const makeGetUploadUrlHandler = (
   db: CosmosDatabase,
@@ -75,25 +76,6 @@ const makeGetUploadUrlHandler = (
     flow(UploadUrlToApiModel.encode, success(UploadUrl))
   );
 };
-
-const configOrError = pipe(
-  getConfigFromEnvironment(process.env),
-  E.getOrElseW(identity)
-);
-
-if (configOrError instanceof Error) {
-  throw configOrError;
-}
-
-const config = configOrError;
-
-const cosmosClient = new CosmosClient(config.azure.cosmos.connectionString);
-const database = cosmosClient.database(config.azure.cosmos.dbName);
-
-const uploadedContainerClient = new ContainerClient(
-  config.azure.storage.connectionString,
-  config.uploadedStorageContainerName
-);
 
 export const run = pipe(
   makeGetUploadUrlHandler(database, uploadedContainerClient),

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/set-signature-request-status.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/set-signature-request-status.ts
@@ -4,13 +4,13 @@ import * as RTE from "fp-ts/lib/ReaderTaskEither";
 import * as RE from "fp-ts/lib/ReaderEither";
 
 import * as azure from "@pagopa/handler-kit/lib/azure";
-import { flow, identity, pipe } from "fp-ts/lib/function";
+import { flow, pipe } from "fp-ts/lib/function";
 import { HttpRequest } from "@pagopa/handler-kit/lib/http";
 import { sequenceS } from "fp-ts/lib/Apply";
 
 import { createHandler } from "@pagopa/handler-kit";
 
-import { CosmosClient, Database as CosmosDatabase } from "@azure/cosmos";
+import { Database as CosmosDatabase } from "@azure/cosmos";
 import { validate } from "@internal/io-sign/validation";
 import { error } from "@internal/io-sign/infra/http/response";
 import { makeRequireSignatureRequest } from "../../http/decoders/signature-request";
@@ -23,7 +23,7 @@ import {
 } from "../cosmos/signature-request";
 
 import { mockGetIssuerBySubscriptionId } from "../../__mocks__/issuer";
-import { getConfigFromEnvironment } from "../../../app/config";
+import { database } from "../cosmos/client";
 
 const makeSetSignatureRequestStatusHandler = (db: CosmosDatabase) => {
   const upsertSignatureRequest = makeUpsertSignatureRequest(db);
@@ -70,20 +70,6 @@ const makeSetSignatureRequestStatusHandler = (db: CosmosDatabase) => {
     () => void 0
   );
 };
-
-const configOrError = pipe(
-  getConfigFromEnvironment(process.env),
-  E.getOrElseW(identity)
-);
-
-if (configOrError instanceof Error) {
-  throw configOrError;
-}
-
-const config = configOrError;
-
-const cosmosClient = new CosmosClient(config.azure.cosmos.connectionString);
-const database = cosmosClient.database(config.azure.cosmos.dbName);
 
 export const run = pipe(
   makeSetSignatureRequestStatusHandler(database),

--- a/apps/io-func-sign-issuer/src/infra/azure/storage/upload-container-client.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/storage/upload-container-client.ts
@@ -1,0 +1,9 @@
+import { ContainerClient } from "@azure/storage-blob";
+import { getConfigOrThrow } from "../../../app/config";
+
+const config = getConfigOrThrow();
+
+export const uploadedContainerClient = new ContainerClient(
+  config.azure.storage.connectionString,
+  config.uploadedStorageContainerName
+);

--- a/apps/io-func-sign-issuer/src/infra/azure/storage/validated-container-client.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/storage/validated-container-client.ts
@@ -1,0 +1,9 @@
+import { ContainerClient } from "@azure/storage-blob";
+import { getConfigOrThrow } from "../../../app/config";
+
+const config = getConfigOrThrow();
+
+export const validatedContainerClient = new ContainerClient(
+  config.azure.storage.connectionString,
+  config.validatedStorageContainerName
+);


### PR DESCRIPTION
#### List of Changes

Make Azure clients singletons.

#### Motivation and Context

Any PaaS client (cosmos, storage, api) must be a singleton in the context of Azure functions otherwise one connection per function is created and since outbound connections have an hard limit it's better to keep them at minimum.

#### How Has This Been Tested?

It has not.
