### PR TITLE
fix: [SFEQS-1141] GetSignatureRequest now serializes the correct Document attributes

### DIFF
--- a/.changeset/honest-radios-cover.md
+++ b/.changeset/honest-radios-cover.md
@@ -1,0 +1,5 @@
+---
+"io-func-sign-issuer": patch
+---
+
+GetSignatureRequest now serialize the correct attributes for each document status [SFEQS-1141]

--- a/apps/io-func-sign-issuer/openapi.yaml
+++ b/apps/io-func-sign-issuer/openapi.yaml
@@ -532,13 +532,6 @@ components:
       properties:
         id:
           $ref: "#/components/schemas/Id"
-        status:
-          type: string
-          enum:
-            - WAIT_FOR_UPLOAD
-            - WAIT_FOR_VALIDATION
-            - READY
-            - REJECTED
         metadata:
           $ref: "#/components/schemas/DocumentMetadata"
         created_at:
@@ -556,15 +549,27 @@ components:
       allOf:
         - $ref: "#/components/schemas/Document"
         - type: object
+          properties:
+            status:
+              type: string
+              enum:
+                - WAIT_FOR_UPLOAD
+          required:
+            - status
 
     DocumentToBeValidated:
       allOf:
         - $ref: "#/components/schemas/Document"
         - type: object
           properties:
+            status:
+              type: string
+              enum:
+                - WAIT_FOR_VALIDATION
             uploaded_at:
               $ref: "#/components/schemas/Timestamp"
           required:
+            - status
             - uploaded_at
 
     DocumentReady:
@@ -572,12 +577,17 @@ components:
         - $ref: "#/components/schemas/Document"
         - type: object
           properties:
+            status:
+              type: string
+              enum:
+                - READY
             uploaded_at:
               $ref: "#/components/schemas/Timestamp"
             url:
               type: string
               format: uri
           required:
+            - status
             - uploaded_at
             - url
 
@@ -586,6 +596,10 @@ components:
         - $ref: "#/components/schemas/Document"
         - type: object
           properties:
+            status:
+              type: string
+              enum:
+                - REJECTED
             uploaded_at:
               $ref: "#/components/schemas/Timestamp"
             rejected_at:
@@ -593,6 +607,7 @@ components:
             reject_reason:
               type: string
           required:
+            - status
             - uploaded_at
             - rejected_at
             - reject_reason

--- a/apps/io-func-sign-issuer/src/infra/http/encoders/document.ts
+++ b/apps/io-func-sign-issuer/src/infra/http/encoders/document.ts
@@ -21,25 +21,6 @@ export const DocumentMetadataToApiModel: E.Encoder<
   }),
 };
 
-const toApiModelEnum = (
-  status: Document["status"]
-):
-  | ReadyStatusEnum
-  | RejectedStatusEnum
-  | ToBeUploadedStatusEnum
-  | ToBeValidatedStatusEnum => {
-  switch (status) {
-    case "READY":
-      return ReadyStatusEnum.READY;
-    case "REJECTED":
-      return RejectedStatusEnum.REJECTED;
-    case "WAIT_FOR_UPLOAD":
-      return ToBeUploadedStatusEnum.WAIT_FOR_UPLOAD;
-    case "WAIT_FOR_VALIDATION":
-      return ToBeValidatedStatusEnum.WAIT_FOR_VALIDATION;
-  }
-};
-
 export const DocumentToApiModel: E.Encoder<DocumentApiModel, Document> = {
   encode: ({
     id,
@@ -50,7 +31,6 @@ export const DocumentToApiModel: E.Encoder<DocumentApiModel, Document> = {
   }) => {
     const commonFields = {
       id,
-      status: toApiModelEnum(additionals.status),
       metadata: DocumentMetadataToApiModel.encode(metadata),
       created_at,
       updated_at,
@@ -59,12 +39,14 @@ export const DocumentToApiModel: E.Encoder<DocumentApiModel, Document> = {
       case "WAIT_FOR_VALIDATION": {
         return {
           ...commonFields,
+          status: ToBeValidatedStatusEnum.WAIT_FOR_VALIDATION,
           uploaded_at: additionals.uploadedAt,
         };
       }
       case "READY": {
         return {
           ...commonFields,
+          status: ReadyStatusEnum.READY,
           uploaded_at: additionals.uploadedAt,
           url: additionals.url,
         };
@@ -72,13 +54,17 @@ export const DocumentToApiModel: E.Encoder<DocumentApiModel, Document> = {
       case "REJECTED": {
         return {
           ...commonFields,
+          status: RejectedStatusEnum.REJECTED,
           uploaded_at: additionals.uploadedAt,
           rejected_at: additionals.rejectedAt,
           reject_reason: additionals.rejectReason,
         };
       }
       default: {
-        return commonFields;
+        return {
+          status: ToBeUploadedStatusEnum.WAIT_FOR_UPLOAD,
+          ...commonFields,
+        };
       }
     }
   },

--- a/apps/io-func-sign-issuer/src/infra/http/encoders/document.ts
+++ b/apps/io-func-sign-issuer/src/infra/http/encoders/document.ts
@@ -4,7 +4,11 @@ import { Document, DocumentMetadata } from "@io-sign/io-sign/document";
 import { DocumentDetailView as DocumentApiModel } from "../models/DocumentDetailView";
 import { DocumentMetadata as DocumentMetadataApiModel } from "../models/DocumentMetadata";
 
-import { StatusEnum as DocumentStatusEnum } from "../models/Document";
+import { StatusEnum as ToBeUploadedStatusEnum } from "../models/DocumentToBeUploaded";
+import { StatusEnum as ToBeValidatedStatusEnum } from "../models/DocumentToBeValidated";
+import { StatusEnum as ReadyStatusEnum } from "../models/DocumentReady";
+import { StatusEnum as RejectedStatusEnum } from "../models/DocumentRejected";
+
 import { SignatureFieldToApiModel } from "./signature-field";
 
 export const DocumentMetadataToApiModel: E.Encoder<
@@ -17,16 +21,22 @@ export const DocumentMetadataToApiModel: E.Encoder<
   }),
 };
 
-const toApiModelEnum = (status: Document["status"]): DocumentStatusEnum => {
+const toApiModelEnum = (
+  status: Document["status"]
+):
+  | ReadyStatusEnum
+  | RejectedStatusEnum
+  | ToBeUploadedStatusEnum
+  | ToBeValidatedStatusEnum => {
   switch (status) {
     case "READY":
-      return DocumentStatusEnum.READY;
+      return ReadyStatusEnum.READY;
     case "REJECTED":
-      return DocumentStatusEnum.REJECTED;
+      return RejectedStatusEnum.REJECTED;
     case "WAIT_FOR_UPLOAD":
-      return DocumentStatusEnum.WAIT_FOR_UPLOAD;
+      return ToBeUploadedStatusEnum.WAIT_FOR_UPLOAD;
     case "WAIT_FOR_VALIDATION":
-      return DocumentStatusEnum.WAIT_FOR_VALIDATION;
+      return ToBeValidatedStatusEnum.WAIT_FOR_VALIDATION;
   }
 };
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. Changed the `openapi spec` in order to discriminate the document statuses

<!--- Describe your changes in detail -->

#### Motivation and Context

Due to the incorrect structure of the OpenAPI specification, some fields of Document were excluded from the responses.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

It was tested manually

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
