### PR TITLE
fix: [SFEQS-1238] Round coordinates for QTSP 

### DIFF
--- a/.changeset/three-forks-shout.md
+++ b/.changeset/three-forks-shout.md
@@ -1,0 +1,5 @@
+---
+"io-func-sign-user": patch
+---
+
+[SFEQS-1238] round coordinates for QTSP

--- a/apps/io-func-sign-user/src/signature-field.ts
+++ b/apps/io-func-sign-user/src/signature-field.ts
@@ -32,7 +32,7 @@ export const toSignatureFieldToBeCreatedAttributes =
   }: AttributesWithCoordsAndSize): SignatureFieldToBeCreatedAttributes => ({
     bottomLeft: {
       x: Math.round(coordinates.x),
-      y: Math.round(pageHeight - coordinates.y + size.h),
+      y: Math.round(pageHeight - coordinates.y -  size.h),
     },
     topRight: {
       x: Math.round(coordinates.x + size.w),

--- a/apps/io-func-sign-user/src/signature-field.ts
+++ b/apps/io-func-sign-user/src/signature-field.ts
@@ -31,12 +31,12 @@ export const toSignatureFieldToBeCreatedAttributes =
     page,
   }: AttributesWithCoordsAndSize): SignatureFieldToBeCreatedAttributes => ({
     bottomLeft: {
-      x: coordinates.x,
-      y: pageHeight - coordinates.y + size.h,
+      x: Math.round(coordinates.x),
+      y: Math.round(pageHeight - coordinates.y + size.h),
     },
     topRight: {
-      x: coordinates.x + size.w,
-      y: pageHeight - coordinates.y,
+      x: Math.round(coordinates.x + size.w),
+      y: Math.round(pageHeight - coordinates.y),
     },
     page,
   });


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. Round coordinates in `io-func-sign-user`, now are all integers

<!--- Describe your changes in detail -->

#### Motivation and Context

The QTSP accepts only integer coordinates

<!--- Why is this change required? What problem does it solve? -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
