### PR TITLE
chore: [SFEQS-1269] Create a custom SAML mock

### DIFF
--- a/.changeset/five-hornets-sort.md
+++ b/.changeset/five-hornets-sort.md
@@ -1,0 +1,6 @@
+---
+"io-func-sign-user": patch
+"@io-sign/io-sign": patch
+---
+
+Added custom SAML mock and implement getFieldValue in PDF infra

--- a/apps/io-func-sign-user/src/app/use-cases/create-signature.ts
+++ b/apps/io-func-sign-user/src/app/use-cases/create-signature.ts
@@ -33,9 +33,9 @@ import {
 import { GetDocumentUrl } from "../../infra/azure/storage/document-url";
 
 import {
-  mockFiscalCode,
   mockPublicKey,
   mockSignature,
+  mockSpidAssertion,
   mockTosSignature,
 } from "./__mocks__/qtsp";
 
@@ -159,6 +159,10 @@ export const makeCreateSignature =
           A.sequence(TE.ApplicativeSeq)
         ),
         tosSignature: pipe(qtspClauses, mockTosSignature),
+        mockedSpidAssertion: pipe(
+          qtspClauses,
+          mockSpidAssertion()(spidAssertion)
+        ),
       }),
       TE.chain((sequence) =>
         pipe(
@@ -170,17 +174,25 @@ export const makeCreateSignature =
           }))
         )
       ),
-      TE.map(({ documentsToSign, tosSignature, signature }) => ({
-        fiscalCode: mockFiscalCode,
-        publicKey: mockPublicKey(),
-        spidAssertion,
-        email,
-        documentLink: qtspClauses.filledDocumentUrl,
-        tosSignature,
-        signature,
-        nonce: qtspClauses.nonce,
-        documentsToSign,
-      })),
+      TE.map(
+        ({
+          documentsToSign,
+          tosSignature,
+          signature,
+          fiscalCode,
+          mockedSpidAssertion,
+        }) => ({
+          fiscalCode,
+          publicKey: mockPublicKey(),
+          spidAssertion: mockedSpidAssertion,
+          email,
+          documentLink: qtspClauses.filledDocumentUrl,
+          tosSignature,
+          signature,
+          nonce: qtspClauses.nonce,
+          documentsToSign,
+        })
+      ),
       TE.chain(creatQtspSignatureRequest),
       TE.filterOrElse(
         (qtspResponse) => qtspResponse.status === "CREATED",

--- a/packages/io-sign/src/infra/pdf.ts
+++ b/packages/io-sign/src/infra/pdf.ts
@@ -66,15 +66,7 @@ export type Field = {
 
 const populate = (form: PDFForm) => (field: Field) =>
   pipe(
-    E.tryCatch(
-      () => form.getTextField(field.fieldName),
-      (e) =>
-        e instanceof Error
-          ? new EntityNotFoundError(e.message)
-          : new EntityNotFoundError(
-              "An error occurred while attempting to access the pdf field."
-            )
-    ),
+    E.tryCatch(() => form.getTextField(field.fieldName), E.toError),
     E.map((textField) => textField.setText(field.fieldValue))
   );
 
@@ -82,16 +74,7 @@ const getFieldValue =
   (form: PDFForm) =>
   (fieldName: string): E.Either<EntityNotFoundError, Field> =>
     pipe(
-      E.tryCatch(
-        () => form.getTextField(fieldName),
-        // eslint-disable-next-line sonarjs/no-identical-functions
-        (e) =>
-          e instanceof Error
-            ? new EntityNotFoundError(e.message)
-            : new EntityNotFoundError(
-                "An error occurred while attempting to access the pdf field."
-              )
-      ),
+      E.tryCatch(() => form.getTextField(fieldName), E.toError),
       E.chain((textField) =>
         pipe(
           textField.getText(),

--- a/packages/io-sign/src/infra/pdf.ts
+++ b/packages/io-sign/src/infra/pdf.ts
@@ -72,11 +72,41 @@ const populate = (form: PDFForm) => (field: Field) =>
         e instanceof Error
           ? new EntityNotFoundError(e.message)
           : new EntityNotFoundError(
-              "An error occurred while attempting to access the pdf fields."
+              "An error occurred while attempting to access the pdf field."
             )
     ),
     E.map((textField) => textField.setText(field.fieldValue))
   );
+
+const getFieldValue =
+  (form: PDFForm) =>
+  (fieldName: string): E.Either<EntityNotFoundError, Field> =>
+    pipe(
+      E.tryCatch(
+        () => form.getTextField(fieldName),
+        // eslint-disable-next-line sonarjs/no-identical-functions
+        (e) =>
+          e instanceof Error
+            ? new EntityNotFoundError(e.message)
+            : new EntityNotFoundError(
+                "An error occurred while attempting to access the pdf field."
+              )
+      ),
+      E.chain((textField) =>
+        pipe(
+          textField.getText(),
+          E.fromNullable(
+            new EntityNotFoundError(
+              "An error occurred while attempting to access the pdf field content."
+            )
+          ),
+          E.map((value) => ({
+            fieldName,
+            fieldValue: value,
+          }))
+        )
+      )
+    );
 
 export const populatePdf = (pdfFields: Field[]) => (buffer: Buffer) =>
   pipe(
@@ -91,3 +121,16 @@ export const populatePdf = (pdfFields: Field[]) => (buffer: Buffer) =>
     ),
     TE.chain((pdfDocument) => TE.tryCatch(() => pdfDocument.save(), toError))
   );
+
+export const getPdfFieldsValue =
+  (pdfFieldsName: string[]) => (buffer: Buffer) =>
+    pipe(
+      buffer,
+      loadPdf,
+      TE.chainEitherK((pdfDocument) =>
+        pipe(
+          pdfFieldsName,
+          A.traverse(E.Applicative)(getFieldValue(pdfDocument.getForm()))
+        )
+      )
+    );


### PR DESCRIPTION
This PR creates a custom Spid Assertion Mock with user data contained in the pdf signature request form.
⚠️ Before deployment requires a change to the `SpidAssertionMock` environment variable

#### Motivation and Context
With this change, the name of the signer on signed PDF will no longer be the same but varies according to the signer.

#### Checklist:
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
