### PR TITLE
chore: [SFEQS-1277] Add support for REJECTED status for signature request.

### DIFF
--- a/.changeset/popular-papayas-buy.md
+++ b/.changeset/popular-papayas-buy.md
@@ -3,5 +3,5 @@
 "@io-sign/io-sign": patch
 ---
 
-Added support for REJECTED status for signature request.
+Added support for REJECTED status for signature request. [SFEQS-1277]
 Added a preliminary status check before signature creation

--- a/.changeset/popular-papayas-buy.md
+++ b/.changeset/popular-papayas-buy.md
@@ -1,0 +1,7 @@
+---
+"io-func-sign-user": minor
+"@io-sign/io-sign": patch
+---
+
+Added support for REJECTED status for signature request.
+Added a preliminary status check before signature creation

--- a/apps/io-func-sign-user/package.json
+++ b/apps/io-func-sign-user/package.json
@@ -16,7 +16,7 @@
     "lint:fix": "eslint --fix \"src/**\"",
     "test": "jest --coverage",
     "typecheck": "tsc",
-    "start": "func start",
+    "start": "func start  --port 7072",
     "build:package": "npm-pack-zip --add-version",
     "generate:api-models": "gen-api-models --api-spec ./openapi.yaml --out-dir ./src/infra/http/models"
   },

--- a/apps/io-func-sign-user/src/app/use-cases/create-signature.ts
+++ b/apps/io-func-sign-user/src/app/use-cases/create-signature.ts
@@ -250,7 +250,7 @@ export const makeCreateSignature =
         !canBeCreated
           ? TE.left(
               new ActionNotAllowedError(
-                "This signature request is in a state that does not allow a siganture to be created!"
+                "Signature can only be created if the signature request is inWAIT_FOR_SIGNATURE or REJECTED status!"
               )
             )
           : createSignatureRequest

--- a/apps/io-func-sign-user/src/app/use-cases/create-signature.ts
+++ b/apps/io-func-sign-user/src/app/use-cases/create-signature.ts
@@ -250,7 +250,7 @@ export const makeCreateSignature =
         !canBeCreated
           ? TE.left(
               new ActionNotAllowedError(
-                "Signature can only be created if the signature request is inWAIT_FOR_SIGNATURE or REJECTED status!"
+                "Signature can only be created if the signature request is in WAIT_FOR_SIGNATURE or REJECTED status!"
               )
             )
           : createSignatureRequest

--- a/apps/io-func-sign-user/src/infra/namirial/client.ts
+++ b/apps/io-func-sign-user/src/infra/namirial/client.ts
@@ -113,6 +113,7 @@ export const makeCreateSignatureRequest =
                 ...defaultHeader,
                 Authorization: `Bearer ${token.access}`,
                 "Content-Transfer-Encoding": "application/json",
+                // TODO: [SFEQS-1296] Source IP mock
                 "X-Forwarded-IP": "192.168.0.1",
                 "X-Forwarded-AppVersion": "pagopa-demo 1.1.1",
                 "X-Forwarded-OS": "Android 12",

--- a/apps/io-func-sign-user/src/signature-request.ts
+++ b/apps/io-func-sign-user/src/signature-request.ts
@@ -164,3 +164,6 @@ export const markAsRejected = (reason: string) =>
     name: "MARK_AS_REJECTED",
     payload: { reason },
   });
+
+export const canBeWaitForQtsp = (request: SignatureRequest) =>
+  pipe(request, dispatch({ name: "MARK_AS_WAIT_FOR_QTSP" }), E.isRight);

--- a/apps/io-func-sign-user/src/signature-request.ts
+++ b/apps/io-func-sign-user/src/signature-request.ts
@@ -67,6 +67,8 @@ const dispatch =
         return pipe(request, onWaitForSignatureStatus(action));
       case "WAIT_FOR_QTSP":
         return pipe(request, onWaitForQtspStatus(action));
+      case "REJECTED":
+        return pipe(request, onRejectedStatus(action));
       default:
         return E.left(
           new ActionNotAllowedError(
@@ -101,6 +103,27 @@ const onWaitForSignatureStatus =
         return E.left(
           new ActionNotAllowedError(
             `${action.name} is prohibited if the signature request is in WAIT_FOR_SIGNATURE status`
+          )
+        );
+    }
+  };
+
+const onRejectedStatus =
+  (action: SignatureRequestAction) =>
+  (
+    request: SignatureRequestRejected
+  ): E.Either<Error, SignatureRequestWaitForQtsp> => {
+    // eslint-disable-next-line sonarjs/no-small-switch
+    switch (action.name) {
+      case "MARK_AS_WAIT_FOR_QTSP":
+        return E.right({
+          ...request,
+          status: "WAIT_FOR_QTSP",
+        });
+      default:
+        return E.left(
+          new ActionNotAllowedError(
+            `${action.name} is prohibited if the signature request is in REJECTED status`
           )
         );
     }

--- a/packages/io-sign/src/signature-request.ts
+++ b/packages/io-sign/src/signature-request.ts
@@ -90,6 +90,7 @@ export const SignatureRequestRejected = makeSignatureRequestVariant(
   t.type({
     rejectedAt: IsoDateFromString,
     rejectReason: t.string,
+    qrCodeUrl: t.string,
     documents: t.array(DocumentReady),
   })
 );


### PR DESCRIPTION
This PR adds support to the `REJECTED` state of the signature request giving the possibility to recreate a signature even when the state is rejected.
It also adds a preliminary status check before proceeding with signature creation. This allows to avoid calling the _QTSP_ if it is not possible to proceed with the signature.
Also moved the local port for `io-func-sign-user` from `7071` to `7072` so that both instances (issuer and user) can be running.


#### How Has This Been Tested?
Tested locally


#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
