### PR TITLE
fix: [SFEQS-1182, SFEQS-1244, SFEQS-1221] Fix rest API responses

### DIFF
--- a/.changeset/lovely-days-admire.md
+++ b/.changeset/lovely-days-admire.md
@@ -1,0 +1,6 @@
+---
+"io-func-sign-issuer": patch
+"@io-sign/io-sign": patch
+---
+
+fix minor bugs on REST API serialization and error responses

--- a/apps/io-func-sign-issuer/openapi.yaml
+++ b/apps/io-func-sign-issuer/openapi.yaml
@@ -654,6 +654,8 @@ components:
           $ref: "#/components/schemas/Timestamp"
         signed_at:
           $ref: "#/components/schemas/Timestamp"
+        rejected_at:
+          $ref: "#/components/schemas/Timestamp"
         reject_reason:
           type: string
         qr_code_url:

--- a/apps/io-func-sign-issuer/openapi.yaml
+++ b/apps/io-func-sign-issuer/openapi.yaml
@@ -363,6 +363,8 @@ components:
       properties:
         title:
           type: string
+          minLength: 5
+          maxLength: 80
         type:
           type: string
           enum: ["REQUIRED", "UNFAIR", "OPTIONAL"]
@@ -422,6 +424,8 @@ components:
       properties:
         title:
           type: string
+          minLength: 3
+          maxLength: 60
         signature_fields:
           type: array
           items:

--- a/apps/io-func-sign-issuer/src/infra/http/encoders/signature-request.ts
+++ b/apps/io-func-sign-issuer/src/infra/http/encoders/signature-request.ts
@@ -60,7 +60,7 @@ export const SignatureRequestToApiModel: E.Encoder<
         return {
           ...commonFields,
           status: SignatureRequestStatusEnum.REJECTED,
-          reject_at: extra.rejectedAt,
+          rejected_at: extra.rejectedAt,
           reject_reason: extra.rejectReason,
         };
       }

--- a/apps/io-func-sign-issuer/src/signature-request.ts
+++ b/apps/io-func-sign-issuer/src/signature-request.ts
@@ -257,7 +257,6 @@ const onDraftStatus =
             )
           )
         );
-        return E.right(request);
       default:
         return E.left(
           new ActionNotAllowedError(

--- a/packages/io-sign/src/infra/http/__test__/errors.spec.ts
+++ b/packages/io-sign/src/infra/http/__test__/errors.spec.ts
@@ -70,11 +70,11 @@ describe("errors", () => {
       expect(isHttpBadRequest).toBe(true);
     });
     it("should parse an InvalidExpiryDateError as HttpBadRequest", () => {
-      const invalidExpiryDateError = new (class extends Error {
-        name = "InvalidExpiryDateError";
+      const InvalidExpireDateError = new (class extends Error {
+        name = "InvalidExpireDateError";
       })("Action not allowed");
       const isHttpBadRequest = pipe(
-        HttpErrorFromError.decode(invalidExpiryDateError),
+        HttpErrorFromError.decode(InvalidExpireDateError),
         E.mapLeft(() => false),
         E.filterOrElse(
           (e) => e.name === "HttpError",

--- a/packages/io-sign/src/infra/http/errors.ts
+++ b/packages/io-sign/src/infra/http/errors.ts
@@ -48,7 +48,7 @@ export const HttpErrorFromError = new t.Type<HttpError, Error, Error>(
         return t.success(new HttpNotFoundError(e.message));
       case "ActionNotAllowedError":
         return t.success(new HttpBadRequestError(e.message));
-      case "InvalidExpiryDateError":
+      case "InvalidExpireDateError":
         return t.success(new HttpBadRequestError(e.message));
       case "TooManyRequestsError":
         return t.success(new HttpTooManyRequestsError(e.message));


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. `rejected_at` is now returned when a `SignatureRequest` is `REJECTED`
2. `CreateDossier` returns `400 (Bad Request)` instead of `500 (Internal Server Error)` when validation fails on `documents_metadata`
3. `CreateSignatureRequest` returns `400 (Bad Request)` instead of `500 (Internal Server Error)` when validations fails on `expires_at`


#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
