### PR TITLE
feat: [SFEQS-1259] Extend Signature Request to include Issuer e-mail and description

### DIFF
--- a/.changeset/rare-cows-fail.md
+++ b/.changeset/rare-cows-fail.md
@@ -1,0 +1,7 @@
+---
+"io-func-sign-issuer": minor
+"io-func-sign-user": minor
+"@io-sign/io-sign": minor
+---
+
+expand signature request to include issuer e-mail and description

--- a/apps/io-func-sign-issuer/src/__test__/signature-request.spec.ts
+++ b/apps/io-func-sign-issuer/src/__test__/signature-request.spec.ts
@@ -8,13 +8,14 @@ import { newId } from "@io-sign/io-sign/id";
 import { Issuer } from "@io-sign/io-sign/issuer";
 import { newDossier } from "../dossier";
 import { newSignatureRequest, withExpiryDate } from "../signature-request";
+import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 
 const issuer: Issuer = {
   id: newId(),
   subscriptionId: newId(),
-  email: "info@enpacl-pec.it",
+  email: "info@enpacl-pec.it" as EmailString,
   address: "Viale Del Caravaggio, 78 - 00147 Roma (RM)",
-  description: "descrizione dell'ente",
+  description: "descrizione dell'ente" as NonEmptyString,
   taxCode: "80119170589",
   vatNumber: "80119170589",
 };
@@ -35,11 +36,11 @@ const dossier = newDossier(issuer, "My dossier", [
 describe("SignatureRequest", () => {
   describe("newSignatureRequest", () => {
     it('should create a request with "DRAFT" status', () => {
-      const request = newSignatureRequest(dossier, newSigner());
+      const request = newSignatureRequest(dossier, newSigner(), issuer);
       expect(request.status).toBe("DRAFT");
     });
     test('all documents should be created with "WAIT_FOR_UPLOAD" status', () => {
-      const request = newSignatureRequest(dossier, newSigner());
+      const request = newSignatureRequest(dossier, newSigner(), issuer);
       expect(
         request.documents.every(
           (document) => document.status === "WAIT_FOR_UPLOAD"
@@ -53,7 +54,7 @@ describe("SignatureRequest", () => {
       const newExpiryDate = pipe(new Date(), addDays(4));
       expect(
         pipe(
-          newSignatureRequest(dossier, newSigner()),
+          newSignatureRequest(dossier, newSigner(), issuer),
           withExpiryDate(newExpiryDate),
           E.map((request) => request.expiresAt),
           E.map(isEqual(newExpiryDate)),
@@ -64,7 +65,7 @@ describe("SignatureRequest", () => {
     it("should return an error on invalid expiry date", () => {
       expect(
         pipe(
-          newSignatureRequest(dossier, newSigner()),
+          newSignatureRequest(dossier, newSigner(), issuer),
           withExpiryDate(pipe(new Date(), subDays(100))),
           E.isLeft
         )

--- a/apps/io-func-sign-issuer/src/__test__/signature-request.spec.ts
+++ b/apps/io-func-sign-issuer/src/__test__/signature-request.spec.ts
@@ -6,9 +6,9 @@ import { addDays, isEqual, subDays } from "date-fns/fp";
 import { newSigner } from "@io-sign/io-sign/signer";
 import { newId } from "@io-sign/io-sign/id";
 import { Issuer } from "@io-sign/io-sign/issuer";
+import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { newDossier } from "../dossier";
 import { newSignatureRequest, withExpiryDate } from "../signature-request";
-import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 
 const issuer: Issuer = {
   id: newId(),

--- a/apps/io-func-sign-issuer/src/__test__/upload.spec.ts
+++ b/apps/io-func-sign-issuer/src/__test__/upload.spec.ts
@@ -15,15 +15,16 @@ import { Issuer } from "@io-sign/io-sign/issuer";
 import { newUploadMetadata } from "../upload";
 import { newSignatureRequest } from "../signature-request";
 import { newDossier } from "../dossier";
+import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 
 describe("UploadMetadata", () => {
   describe("newUploadMetadata", () => {
     const issuer: Issuer = {
       id: newId(),
       subscriptionId: newId(),
-      email: "info@enpacl-pec.it",
+      email: "info@enpacl-pec.it" as EmailString,
       address: "Viale Del Caravaggio, 78 - 00147 Roma (RM)",
-      description: "descrizione dell'ente",
+      description: "descrizione dell'ente" as NonEmptyString,
       taxCode: "80119170589",
       vatNumber: "80119170589",
     };
@@ -41,7 +42,7 @@ describe("UploadMetadata", () => {
       },
     ]);
 
-    const request = newSignatureRequest(dossier, newSigner());
+    const request = newSignatureRequest(dossier, newSigner(), issuer);
 
     it("should create an UploadMetadata record only if the specified document exists", () => {
       const metaForFirstDocument = pipe(

--- a/apps/io-func-sign-issuer/src/__test__/upload.spec.ts
+++ b/apps/io-func-sign-issuer/src/__test__/upload.spec.ts
@@ -12,10 +12,10 @@ import { head } from "fp-ts/lib/Array";
 import { newSigner } from "@io-sign/io-sign/signer";
 
 import { Issuer } from "@io-sign/io-sign/issuer";
+import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { newUploadMetadata } from "../upload";
 import { newSignatureRequest } from "../signature-request";
 import { newDossier } from "../dossier";
-import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 
 describe("UploadMetadata", () => {
   describe("newUploadMetadata", () => {

--- a/apps/io-func-sign-issuer/src/app/use-cases/create-signature-request.ts
+++ b/apps/io-func-sign-issuer/src/app/use-cases/create-signature-request.ts
@@ -1,4 +1,5 @@
 import { Signer } from "@io-sign/io-sign/signer";
+import { Issuer } from "@io-sign/io-sign/issuer";
 
 import * as O from "fp-ts/lib/Option";
 import * as TE from "fp-ts/lib/TaskEither";
@@ -16,13 +17,14 @@ export type CreateSignatureRequestPayload = {
   dossier: Dossier;
   signer: Signer;
   expiresAt: O.Option<Date>;
+  issuer: Issuer;
 };
 
 export const makeCreateSignatureRequest =
   (insertSignatureRequest: InsertSignatureRequest) =>
-  ({ dossier, signer, expiresAt }: CreateSignatureRequestPayload) =>
+  ({ dossier, signer, expiresAt, issuer }: CreateSignatureRequestPayload) =>
     pipe(
-      newSignatureRequest(dossier, signer),
+      newSignatureRequest(dossier, signer, issuer),
       withExpiryDate(pipe(expiresAt, O.getOrElse(defaultExpiryDate))),
       TE.fromEither,
       TE.chain(insertSignatureRequest)

--- a/apps/io-func-sign-issuer/src/signature-request.ts
+++ b/apps/io-func-sign-issuer/src/signature-request.ts
@@ -34,6 +34,7 @@ import {
 } from "@io-sign/io-sign/signature-request";
 
 import { Dossier } from "./dossier";
+import { Issuer } from "@io-sign/io-sign/issuer";
 
 export const SignatureRequestDraft = makeSignatureRequestVariant(
   "DRAFT",
@@ -58,10 +59,13 @@ export const defaultExpiryDate = () => pipe(new Date(), addDays(90));
 
 export const newSignatureRequest = (
   dossier: Dossier,
-  signer: Signer
+  signer: Signer,
+  issuer: Issuer
 ): SignatureRequest => ({
   id: newId(),
   issuerId: dossier.issuerId,
+  issuerEmail: issuer.email,
+  issuerDescription: issuer.description,
   signerId: signer.id,
   dossierId: dossier.id,
   status: "DRAFT",

--- a/apps/io-func-sign-issuer/src/signature-request.ts
+++ b/apps/io-func-sign-issuer/src/signature-request.ts
@@ -33,8 +33,8 @@ import {
   makeSignatureRequestVariant,
 } from "@io-sign/io-sign/signature-request";
 
-import { Dossier } from "./dossier";
 import { Issuer } from "@io-sign/io-sign/issuer";
+import { Dossier } from "./dossier";
 
 export const SignatureRequestDraft = makeSignatureRequestVariant(
   "DRAFT",

--- a/apps/io-func-sign-user/openapi.yaml
+++ b/apps/io-func-sign-user/openapi.yaml
@@ -579,6 +579,18 @@ components:
             - WAIT_FOR_QTSP
             - SIGNED
             - REJECTED
+        issuer:
+          type: object
+          properties:
+            email:
+              type: string
+              format: email
+            description:
+              type: string
+              minLength: 1
+          required:
+            - email
+            - description
         dossier_id:
           $ref: "#/components/schemas/Id"
         signer_id:
@@ -599,6 +611,7 @@ components:
       required:
         - id
         - status
+        - issuer
         - dossier_id
         - signer_id
         - expires_at

--- a/apps/io-func-sign-user/src/__test__/signature-request.spec.ts
+++ b/apps/io-func-sign-user/src/__test__/signature-request.spec.ts
@@ -3,6 +3,8 @@ import { describe, it, expect } from "@jest/globals";
 import { pipe } from "fp-ts/lib/function";
 import * as E from "fp-ts/lib/Either";
 
+import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+
 import { newId } from "@io-sign/io-sign/id";
 import {
   markAsRejected,
@@ -16,6 +18,8 @@ const signatureRequest: SignatureRequest = {
   id: newId(),
   dossierId: newId(),
   issuerId: newId(),
+  issuerEmail: "issuer@io-sign-mail.it" as EmailString,
+  issuerDescription: "Mocked Issuer" as NonEmptyString,
   signerId: newId(),
   createdAt: new Date(),
   updatedAt: new Date(),

--- a/apps/io-func-sign-user/src/infra/http/encoders/signature-request.ts
+++ b/apps/io-func-sign-user/src/infra/http/encoders/signature-request.ts
@@ -20,6 +20,8 @@ export const SignatureRequestToApiModel: E.Encoder<
     createdAt: created_at,
     updatedAt: updated_at,
     expiresAt: expires_at,
+    issuerEmail: email,
+    issuerDescription: description,
     documents,
     ...extra
   }) => {
@@ -31,6 +33,10 @@ export const SignatureRequestToApiModel: E.Encoder<
       updated_at,
       expires_at,
       documents: documents.map(DocumentReadyToDetailView.encode),
+      issuer: {
+        email,
+        description,
+      },
     };
     switch (extra.status) {
       case "WAIT_FOR_SIGNATURE": {

--- a/packages/io-sign/src/issuer.ts
+++ b/packages/io-sign/src/issuer.ts
@@ -1,15 +1,15 @@
 import * as t from "io-ts";
 
-import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 
 import { Id } from "./id";
 
 export const Issuer = t.type({
   id: Id,
   subscriptionId: NonEmptyString,
-  email: t.string,
+  email: EmailString,
   address: t.string,
-  description: t.string,
+  description: NonEmptyString,
   taxCode: t.string,
   vatNumber: t.string,
 });

--- a/packages/io-sign/src/signature-request.ts
+++ b/packages/io-sign/src/signature-request.ts
@@ -1,6 +1,7 @@
 import * as t from "io-ts";
 
 import { IsoDateFromString } from "@pagopa/ts-commons/lib/dates";
+import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 
 import { Id } from "./id";
 import { Signer } from "./signer";
@@ -12,6 +13,9 @@ const SignatureRequest = t.type({
   id: Id,
   signerId: Signer.props.id,
   issuerId: Issuer.props.id,
+  // TODO: [SFEQS-1028] issuerEmail and IssuerDescription are temp properties, waiting to implement the integration with Selfcare.
+  issuerEmail: EmailString,
+  issuerDescription: NonEmptyString,
   dossierId: Id,
   createdAt: IsoDateFromString,
   updatedAt: IsoDateFromString,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. Add `issuerDescription` and `issuerEmail` field in `SignatureRequest`
2. Extend `io-func-sign-user`'s OpenAPI spec to include `issuer` property with `e-mail` and `description`

<!--- Describe your changes in detail -->

#### Motivation and Context

This issuer data is requested in the mobile screens. At the moment they are persisted in the Signature Request as we are not yet integrated into Selfcare.

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
