### PR TITLE
[SFEQS-1222] Keep Signature Request statuses consistent across the system

### DIFF
--- a/.changeset/wet-boats-wash.md
+++ b/.changeset/wet-boats-wash.md
@@ -1,0 +1,6 @@
+---
+"io-func-sign-issuer": minor
+"io-func-sign-user": minor
+---
+
+Add functions to sync Signature Request statuses across the system

--- a/apps/io-func-sign-issuer/MarkAsRejected/function.json
+++ b/apps/io-func-sign-issuer/MarkAsRejected/function.json
@@ -1,0 +1,14 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "queueTrigger",
+      "direction": "in",
+      "name": "signatureRequest",
+      "queueName": "on-signature-request-rejected",
+      "connection": "StorageAccountConnectionString"
+    }
+  ],
+  "scriptFile": "../dist/main.js",
+  "entryPoint": "MarkAsRejected"
+}

--- a/apps/io-func-sign-issuer/MarkAsSigned/function.json
+++ b/apps/io-func-sign-issuer/MarkAsSigned/function.json
@@ -1,0 +1,14 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "queueTrigger",
+      "direction": "in",
+      "name": "signatureRequest",
+      "queueName": "on-signature-request-signed",
+      "connection": "StorageAccountConnectionString"
+    }
+  ],
+  "scriptFile": "../dist/main.js",
+  "entryPoint": "MarkAsSigned"
+}

--- a/apps/io-func-sign-issuer/src/app/main.ts
+++ b/apps/io-func-sign-issuer/src/app/main.ts
@@ -19,6 +19,8 @@ import { makeSendNotificationFunction } from "../infra/azure/functions/send-noti
 import { makeSetSignatureRequestStatusFunction } from "../infra/azure/functions/set-signature-request-status";
 import { makeValidateUploadFunction } from "../infra/azure/functions/validate-upload";
 import { makeRequestAsWaitForSignatureFunction } from "../infra/azure/functions/mark-as-wait-for-signature";
+import { makeRequestAsRejectedFunction } from "../infra/azure/functions/mark-as-rejected";
+import { makeRequestAsSignedFunction } from "../infra/azure/functions/mark-as-signed";
 
 import { getConfigFromEnvironment } from "./config";
 
@@ -82,6 +84,10 @@ export const SetSignatureRequestStatus = makeSetSignatureRequestStatusFunction(
 );
 export const MarkAsWaitForSignature =
   makeRequestAsWaitForSignatureFunction(database);
+
+export const MarkAsRejected = makeRequestAsRejectedFunction(database);
+
+export const MarkAsSigned = makeRequestAsSignedFunction(database);
 
 export const GetSignerByFiscalCode = makeGetSignerFunction(
   pdvTokenizerClientWithApiKey,

--- a/apps/io-func-sign-issuer/src/app/use-cases/mark-request-rejected.ts
+++ b/apps/io-func-sign-issuer/src/app/use-cases/mark-request-rejected.ts
@@ -1,0 +1,28 @@
+import { EntityNotFoundError } from "@io-sign/io-sign/error";
+import { SignatureRequestRejected } from "@io-sign/io-sign/signature-request";
+import { pipe } from "fp-ts/lib/function";
+
+import * as TE from "fp-ts/lib/TaskEither";
+
+import {
+  UpsertSignatureRequest,
+  markAsRejected,
+  GetSignatureRequest,
+} from "../../signature-request";
+
+export const makeMarkRequestAsRejected =
+  (
+    getSignatureRequest: GetSignatureRequest,
+    upsertSignatureRequest: UpsertSignatureRequest
+  ) =>
+  (request: SignatureRequestRejected) =>
+    pipe(
+      pipe(request.issuerId, getSignatureRequest(request.id)),
+      TE.chain(
+        TE.fromOption(
+          () => new EntityNotFoundError("Signature Request not found.")
+        )
+      ),
+      TE.chainEitherK(markAsRejected(request.rejectedAt, request.rejectReason)),
+      TE.chain(upsertSignatureRequest)
+    );

--- a/apps/io-func-sign-issuer/src/app/use-cases/mark-request-signed.ts
+++ b/apps/io-func-sign-issuer/src/app/use-cases/mark-request-signed.ts
@@ -1,0 +1,28 @@
+import { EntityNotFoundError } from "@io-sign/io-sign/error";
+import { SignatureRequestSigned } from "@io-sign/io-sign/signature-request";
+import { pipe } from "fp-ts/lib/function";
+
+import * as TE from "fp-ts/lib/TaskEither";
+
+import {
+  UpsertSignatureRequest,
+  markAsSigned,
+  GetSignatureRequest,
+} from "../../signature-request";
+
+export const makeMarkRequestAsSigned =
+  (
+    getSignatureRequest: GetSignatureRequest,
+    upsertSignatureRequest: UpsertSignatureRequest
+  ) =>
+  (request: SignatureRequestSigned) =>
+    pipe(
+      pipe(request.issuerId, getSignatureRequest(request.id)),
+      TE.chain(
+        TE.fromOption(
+          () => new EntityNotFoundError("Signature Request not found.")
+        )
+      ),
+      TE.chainEitherK(markAsSigned),
+      TE.chain(upsertSignatureRequest)
+    );

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/mark-as-rejected.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/mark-as-rejected.ts
@@ -1,0 +1,43 @@
+import { Database } from "@azure/cosmos";
+
+import * as azure from "@pagopa/handler-kit/lib/azure";
+import { createHandler } from "@pagopa/handler-kit";
+
+import * as TE from "fp-ts/lib/TaskEither";
+import { identity, flow } from "fp-ts/lib/function";
+
+import { SignatureRequestRejected } from "@io-sign/io-sign/signature-request";
+
+import {
+  makeGetSignatureRequest,
+  makeUpsertSignatureRequest,
+} from "../cosmos/signature-request";
+
+import { makeMarkRequestAsRejected } from "../../../app/use-cases/mark-request-rejected";
+
+const makeRequestAsRejectedHandler = (db: Database) => {
+  const getSignatureRequestFromQueue = flow(
+    azure.fromQueueMessage(SignatureRequestRejected),
+    TE.fromEither
+  );
+
+  const getSignatureRequest = makeGetSignatureRequest(db);
+  const upsertSignatureRequest = makeUpsertSignatureRequest(db);
+
+  const markAsRejected = makeMarkRequestAsRejected(
+    getSignatureRequest,
+    upsertSignatureRequest
+  );
+
+  return createHandler(
+    getSignatureRequestFromQueue,
+    markAsRejected,
+    identity,
+    () => undefined
+  );
+};
+
+export const makeRequestAsRejectedFunction = flow(
+  makeRequestAsRejectedHandler,
+  azure.unsafeRun
+);

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/mark-as-signed.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/mark-as-signed.ts
@@ -1,0 +1,41 @@
+import { Database } from "@azure/cosmos";
+
+import * as azure from "@pagopa/handler-kit/lib/azure";
+import { createHandler } from "@pagopa/handler-kit";
+
+import * as TE from "fp-ts/lib/TaskEither";
+import { identity, flow } from "fp-ts/lib/function";
+
+import { SignatureRequestSigned } from "@io-sign/io-sign/signature-request";
+
+import {
+  makeGetSignatureRequest,
+  makeUpsertSignatureRequest,
+} from "../cosmos/signature-request";
+import { makeMarkRequestAsSigned } from "../../../app/use-cases/mark-request-signed";
+
+const makeRequestAsSignedHandler = (db: Database) => {
+  const getSignatureRequestFromQueue = flow(
+    azure.fromQueueMessage(SignatureRequestSigned),
+    TE.fromEither
+  );
+  const getSignatureRequest = makeGetSignatureRequest(db);
+  const upsertSignatureRequest = makeUpsertSignatureRequest(db);
+
+  const markAsSigned = makeMarkRequestAsSigned(
+    getSignatureRequest,
+    upsertSignatureRequest
+  );
+
+  return createHandler(
+    getSignatureRequestFromQueue,
+    markAsSigned,
+    identity,
+    () => undefined
+  );
+};
+
+export const makeRequestAsSignedFunction = flow(
+  makeRequestAsSignedHandler,
+  azure.unsafeRun
+);

--- a/apps/io-func-sign-user/src/app/main.ts
+++ b/apps/io-func-sign-user/src/app/main.ts
@@ -53,6 +53,16 @@ const onWaitForSignatureQueueClient = new QueueClient(
   "on-signature-request-wait-for-signature"
 );
 
+const onSignedQueueClient = new QueueClient(
+  config.azure.storage.connectionString,
+  "on-signature-request-signed"
+);
+
+const onRejectedQueueClient = new QueueClient(
+  config.azure.storage.connectionString,
+  "on-signature-request-rejected"
+);
+
 const validatedContainerClient = new ContainerClient(
   config.azure.storage.connectionString,
   "validated-documents"
@@ -132,5 +142,7 @@ export const ValidateSignature = makeValidateSignatureFunction(
   pdvTokenizerClient,
   database,
   signedContainerClient,
-  config.namirial
+  config.namirial,
+  onSignedQueueClient,
+  onRejectedQueueClient
 );

--- a/apps/io-func-sign-user/src/infra/azure/functions/create-signature-request.ts
+++ b/apps/io-func-sign-user/src/infra/azure/functions/create-signature-request.ts
@@ -11,7 +11,7 @@ import { SignatureRequestReady } from "@io-sign/io-sign/signature-request";
 import { QueueClient } from "@azure/storage-queue";
 import { makeInsertSignatureRequest } from "../cosmos/signature-request";
 import { makeCreateSignatureRequest } from "../../../app/use-cases/create-signature-request";
-import { makeNotifySignatureRequestReadyEvent } from "../storage/signature-request";
+import { makeNotifySignatureRequestWaitForSignatureEvent } from "../storage/signature-request";
 
 const makeCreateSignatureRequestHandler = (
   db: Database,
@@ -23,7 +23,9 @@ const makeCreateSignatureRequestHandler = (
   );
   const createSignatureRequest = makeCreateSignatureRequest(
     makeInsertSignatureRequest(db),
-    makeNotifySignatureRequestReadyEvent(onWaitForSignatureQueueClient)
+    makeNotifySignatureRequestWaitForSignatureEvent(
+      onWaitForSignatureQueueClient
+    )
   );
   return createHandler(
     getSignatureRequestFromQueue,

--- a/apps/io-func-sign-user/src/infra/azure/storage/signature-request.ts
+++ b/apps/io-func-sign-user/src/infra/azure/storage/signature-request.ts
@@ -2,9 +2,23 @@ import { QueueClient } from "@azure/storage-queue";
 
 import { enqueue } from "@io-sign/io-sign/infra/azure/storage/queue";
 import { pipe } from "fp-ts/lib/function";
-import { NotifySignatureRequestWaitForSignatureEvent } from "../../../signature-request";
+import {
+  NotifySignatureRequestWaitForSignatureEvent,
+  NotifySignatureRequestSignedEvent,
+  NotifySignatureRequestRejectedEvent,
+} from "../../../signature-request";
 
-export const makeNotifySignatureRequestReadyEvent =
+export const makeNotifySignatureRequestWaitForSignatureEvent =
   (queueClient: QueueClient): NotifySignatureRequestWaitForSignatureEvent =>
+  (request) =>
+    pipe(queueClient, enqueue(request));
+
+export const makeNotifySignatureRequestSignedEvent =
+  (queueClient: QueueClient): NotifySignatureRequestSignedEvent =>
+  (request) =>
+    pipe(queueClient, enqueue(request));
+
+export const makeNotifySignatureRequestRejectedEvent =
+  (queueClient: QueueClient): NotifySignatureRequestRejectedEvent =>
   (request) =>
     pipe(queueClient, enqueue(request));

--- a/apps/io-func-sign-user/src/signature-request.ts
+++ b/apps/io-func-sign-user/src/signature-request.ts
@@ -39,6 +39,14 @@ export type NotifySignatureRequestWaitForSignatureEvent = (
   requestToBeSigned: SignatureRequestToBeSigned
 ) => TE.TaskEither<Error, string>;
 
+export type NotifySignatureRequestSignedEvent = (
+  requestSigned: SignatureRequestSigned
+) => TE.TaskEither<Error, string>;
+
+export type NotifySignatureRequestRejectedEvent = (
+  requestRejected: SignatureRequestRejected
+) => TE.TaskEither<Error, string>;
+
 type Action_MARK_AS_SIGNED = {
   name: "MARK_AS_SIGNED";
 };


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. Add two functions on the issuer side `MarkAsSigned` and `MarkAsRejected`
2. Add event emitters (backed by Azure Storage Queue)

<!--- Describe your changes in detail -->

#### Motivation and Context

since the signature request is stored in two separate databases, we have to keep them in sync

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
