### PR TITLE
chore!: [SFEQS-1333] Add the ability to mark an issuer as a no-billable test account

### DIFF
--- a/.changeset/tame-pandas-applaud.md
+++ b/.changeset/tame-pandas-applaud.md
@@ -1,0 +1,5 @@
+---
+"@io-sign/io-sign": patch
+---
+
+Add isTrying to issuer data model

--- a/.changeset/tame-pandas-applaud.md
+++ b/.changeset/tame-pandas-applaud.md
@@ -2,4 +2,4 @@
 "@io-sign/io-sign": patch
 ---
 
-Add isTesting to issuer data model
+Add environment to issuer data model

--- a/.changeset/tame-pandas-applaud.md
+++ b/.changeset/tame-pandas-applaud.md
@@ -2,4 +2,4 @@
 "@io-sign/io-sign": patch
 ---
 
-Add isTrying to issuer data model
+Add isTesting to issuer data model

--- a/apps/io-func-sign-issuer/src/__test__/signature-request.spec.ts
+++ b/apps/io-func-sign-issuer/src/__test__/signature-request.spec.ts
@@ -15,7 +15,7 @@ const issuer: Issuer = {
   subscriptionId: newId(),
   email: "info@enpacl-pec.it" as EmailString,
   description: "descrizione dell'ente" as NonEmptyString,
-  isTrying: true,
+  isTesting: true,
 };
 
 const dossier = newDossier(issuer, "My dossier", [

--- a/apps/io-func-sign-issuer/src/__test__/signature-request.spec.ts
+++ b/apps/io-func-sign-issuer/src/__test__/signature-request.spec.ts
@@ -14,10 +14,8 @@ const issuer: Issuer = {
   id: newId(),
   subscriptionId: newId(),
   email: "info@enpacl-pec.it" as EmailString,
-  address: "Viale Del Caravaggio, 78 - 00147 Roma (RM)",
   description: "descrizione dell'ente" as NonEmptyString,
-  taxCode: "80119170589",
-  vatNumber: "80119170589",
+  isTrying: true,
 };
 
 const dossier = newDossier(issuer, "My dossier", [

--- a/apps/io-func-sign-issuer/src/__test__/signature-request.spec.ts
+++ b/apps/io-func-sign-issuer/src/__test__/signature-request.spec.ts
@@ -15,7 +15,7 @@ const issuer: Issuer = {
   subscriptionId: newId(),
   email: "info@enpacl-pec.it" as EmailString,
   description: "descrizione dell'ente" as NonEmptyString,
-  isTesting: true,
+  environment: "TEST",
 };
 
 const dossier = newDossier(issuer, "My dossier", [

--- a/apps/io-func-sign-issuer/src/__test__/upload.spec.ts
+++ b/apps/io-func-sign-issuer/src/__test__/upload.spec.ts
@@ -24,7 +24,7 @@ describe("UploadMetadata", () => {
       subscriptionId: newId(),
       email: "info@enpacl-pec.it" as EmailString,
       description: "descrizione dell'ente" as NonEmptyString,
-      isTesting: true,
+      environment: "TEST",
     };
 
     const dossier = newDossier(issuer, "My dossier", [

--- a/apps/io-func-sign-issuer/src/__test__/upload.spec.ts
+++ b/apps/io-func-sign-issuer/src/__test__/upload.spec.ts
@@ -24,7 +24,7 @@ describe("UploadMetadata", () => {
       subscriptionId: newId(),
       email: "info@enpacl-pec.it" as EmailString,
       description: "descrizione dell'ente" as NonEmptyString,
-      isTrying: true,
+      isTesting: true,
     };
 
     const dossier = newDossier(issuer, "My dossier", [

--- a/apps/io-func-sign-issuer/src/__test__/upload.spec.ts
+++ b/apps/io-func-sign-issuer/src/__test__/upload.spec.ts
@@ -23,10 +23,8 @@ describe("UploadMetadata", () => {
       id: newId(),
       subscriptionId: newId(),
       email: "info@enpacl-pec.it" as EmailString,
-      address: "Viale Del Caravaggio, 78 - 00147 Roma (RM)",
       description: "descrizione dell'ente" as NonEmptyString,
-      taxCode: "80119170589",
-      vatNumber: "80119170589",
+      isTrying: true,
     };
 
     const dossier = newDossier(issuer, "My dossier", [

--- a/packages/io-sign/src/issuer.ts
+++ b/packages/io-sign/src/issuer.ts
@@ -4,13 +4,19 @@ import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 
 import { Id } from "./id";
 
+export const IssuerEnvironment = t.union([
+  t.literal("TEST"),
+  t.literal("DEFAULT"),
+]);
+export type IssuerEnvironment = t.TypeOf<typeof IssuerEnvironment>;
+
 export const Issuer = t.type({
   id: Id,
   subscriptionId: NonEmptyString,
   email: EmailString,
   description: NonEmptyString,
   // The need is to know if an issuer is in the experimental phase or not
-  isTesting: t.boolean,
+  environment: IssuerEnvironment,
 });
 
 export type Issuer = t.TypeOf<typeof Issuer>;

--- a/packages/io-sign/src/issuer.ts
+++ b/packages/io-sign/src/issuer.ts
@@ -9,7 +9,7 @@ export const Issuer = t.type({
   subscriptionId: NonEmptyString,
   email: EmailString,
   description: NonEmptyString,
-  isTrying: t.boolean,
+  isTesting: t.boolean,
 });
 
 export type Issuer = t.TypeOf<typeof Issuer>;

--- a/packages/io-sign/src/issuer.ts
+++ b/packages/io-sign/src/issuer.ts
@@ -9,6 +9,7 @@ export const Issuer = t.type({
   subscriptionId: NonEmptyString,
   email: EmailString,
   description: NonEmptyString,
+  // The need is to know if an issuer is in the experimental phase or not
   isTesting: t.boolean,
 });
 

--- a/packages/io-sign/src/issuer.ts
+++ b/packages/io-sign/src/issuer.ts
@@ -8,10 +8,8 @@ export const Issuer = t.type({
   id: Id,
   subscriptionId: NonEmptyString,
   email: EmailString,
-  address: t.string,
   description: NonEmptyString,
-  taxCode: t.string,
-  vatNumber: t.string,
+  isTrying: t.boolean,
 });
 
 export type Issuer = t.TypeOf<typeof Issuer>;


### PR DESCRIPTION
This PR add isTrying field to issuer data and remove unused fields.

#### Motivation and Context
The need is to know if an issuer is in the experimental phase or not. We will use this field to communicate to data-lake whether the signing event should be billed or not and at the same time to route the request to the QTSP towards a demo or production environment. The addition has been made now to avoid breaking changes during the initial experimentation.

#### Checklist:
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
