### PR TITLE
fix(issuer): [SFEQS-1348] Pre-authenticate urls on SIGNED requests

### DIFF
--- a/.changeset/silly-drinks-turn.md
+++ b/.changeset/silly-drinks-turn.md
@@ -1,0 +1,7 @@
+---
+"io-func-sign-issuer": patch
+"io-func-sign-user": patch
+"@io-sign/io-sign": patch
+---
+
+pre-authenticate urls on signed signature requests (issuer)

--- a/apps/io-func-sign-issuer/src/app/main.ts
+++ b/apps/io-func-sign-issuer/src/app/main.ts
@@ -58,6 +58,11 @@ const validatedContainerClient = new ContainerClient(
   "validated-documents"
 );
 
+const signedContainerClient = new ContainerClient(
+  config.azure.storage.connectionString,
+  "signed-documents"
+);
+
 const onSignatureRequestReadyQueueClient = new QueueClient(
   config.azure.storage.connectionString,
   "on-signature-request-ready"
@@ -77,7 +82,10 @@ export const GetDossier = makeGetDossierFunction(database);
 
 export const CreateSignatureRequest =
   makeCreateSignatureRequestFunction(database);
-export const GetSignatureRequest = makeGetSignatureRequestFunction(database);
+export const GetSignatureRequest = makeGetSignatureRequestFunction(
+  database,
+  signedContainerClient
+);
 export const SetSignatureRequestStatus = makeSetSignatureRequestStatusFunction(
   database,
   onSignatureRequestReadyQueueClient

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/get-signature-request.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/get-signature-request.ts
@@ -6,17 +6,44 @@ import { error, success } from "@io-sign/io-sign/infra/http/response";
 
 import * as azure from "@pagopa/handler-kit/lib/azure";
 
-import { flow } from "fp-ts/lib/function";
 import { createHandler } from "@pagopa/handler-kit";
-import { SignatureRequestToApiModel } from "../../http/encoders/signature-request";
-import { SignatureRequestDetailView } from "../../http/models/SignatureRequestDetailView";
-import { makeRequireSignatureRequest } from "../../http/decoders/signature-request";
-import { makeGetSignatureRequest } from "../cosmos/signature-request";
-import { makeGetIssuerBySubscriptionId } from "../cosmos/issuer";
+import { ContainerClient } from "@azure/storage-blob";
 
-const makeGetSignatureRequestHandler = (db: CosmosDatabase) => {
+import { pipe, flow } from "fp-ts/function";
+import { map, sequence } from "fp-ts/lib/Array";
+
+import { toDocumentWithSasUrl } from "@io-sign/io-sign/infra/azure/storage/document-url";
+
+import * as RTE from "fp-ts/lib/ReaderTaskEither";
+
+import { SignatureRequestSigned } from "@io-sign/io-sign/signature-request";
+import { makeGetIssuerBySubscriptionId } from "../cosmos/issuer";
+import { makeGetSignatureRequest } from "../cosmos/signature-request";
+import { makeRequireSignatureRequest } from "../../http/decoders/signature-request";
+import { SignatureRequestDetailView } from "../../http/models/SignatureRequestDetailView";
+import { SignatureRequestToApiModel } from "../../http/encoders/signature-request";
+
+const makeGrantReadAccessToDocuments =
+  (containerClient: ContainerClient) => (request: SignatureRequestSigned) =>
+    pipe(
+      request.documents,
+      map(toDocumentWithSasUrl("r", 5)),
+      sequence(RTE.ApplicativeSeq),
+      RTE.map(
+        (documents): SignatureRequestSigned => ({ ...request, documents })
+      )
+    )(containerClient);
+
+const makeGetSignatureRequestHandler = (
+  db: CosmosDatabase,
+  signedContainerClient: ContainerClient
+) => {
   const getSignatureRequest = makeGetSignatureRequest(db);
   const getIssuerBySubscriptionId = makeGetIssuerBySubscriptionId(db);
+
+  const grantReadAccessToDocuments = makeGrantReadAccessToDocuments(
+    signedContainerClient
+  );
 
   const requireSignatureRequest = makeRequireSignatureRequest(
     getIssuerBySubscriptionId,
@@ -36,7 +63,16 @@ const makeGetSignatureRequestHandler = (db: CosmosDatabase) => {
 
   return createHandler(
     decodeHttpRequest,
-    TE.right,
+    (request) =>
+      pipe(
+        SignatureRequestSigned.decode(request),
+        TE.fromEither,
+        TE.mapLeft(
+          () => new Error(`The Signature Request Status is ${request.status}.`)
+        ),
+        TE.chain(grantReadAccessToDocuments),
+        TE.alt(() => TE.right(request))
+      ),
     error,
     encodeHttpSuccessResponse
   );

--- a/apps/io-func-sign-user/src/app/use-cases/create-signature.ts
+++ b/apps/io-func-sign-user/src/app/use-cases/create-signature.ts
@@ -15,6 +15,7 @@ import { Id } from "@io-sign/io-sign/id";
 
 import { sequenceS } from "fp-ts/lib/Apply";
 import { validate } from "@io-sign/io-sign/validation";
+import { GetDocumentUrl } from "@io-sign/io-sign/document-url";
 import { QtspClauses } from "../../qtsp";
 import { CreateSignatureRequest as CreateQtspSignatureRequest } from "../../infra/namirial/signature-request";
 
@@ -31,7 +32,6 @@ import {
   markAsWaitForQtsp,
   UpsertSignatureRequest,
 } from "../../signature-request";
-import { GetDocumentUrl } from "../../infra/azure/storage/document-url";
 
 import {
   mockPublicKey,

--- a/apps/io-func-sign-user/src/infra/azure/functions/create-signature.ts
+++ b/apps/io-func-sign-user/src/infra/azure/functions/create-signature.ts
@@ -19,6 +19,8 @@ import { QueueClient } from "@azure/storage-queue";
 import { ContainerClient } from "@azure/storage-blob";
 import { DocumentReady } from "@io-sign/io-sign/document";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { getDocumentUrl } from "@io-sign/io-sign/infra/azure/storage/document-url";
+import { GetDocumentUrl } from "@io-sign/io-sign/document-url";
 import { requireSigner } from "../../http/decoder/signer";
 import { CreateSignatureBody } from "../../http/models/CreateSignatureBody";
 import { requireDocumentsSignature } from "../../http/decoder/document-to-sign";
@@ -42,7 +44,7 @@ import {
   makeGetSignatureRequest,
   makeUpsertSignatureRequest,
 } from "../cosmos/signature-request";
-import { GetDocumentUrl, getDocumentUrl } from "../storage/document-url";
+
 import { makeNotifySignatureReadyEvent } from "../storage/signature";
 
 const makeCreateSignatureHandler = (

--- a/apps/io-func-sign-user/src/infra/azure/functions/get-signature-request.ts
+++ b/apps/io-func-sign-user/src/infra/azure/functions/get-signature-request.ts
@@ -13,12 +13,12 @@ import { ContainerClient } from "@azure/storage-blob";
 
 import { map, sequence } from "fp-ts/lib/Array";
 
+import { toDocumentWithSasUrl } from "@io-sign/io-sign/infra/azure/storage/document-url";
 import { SignatureRequestDetailView } from "../../http/models/SignatureRequestDetailView";
 import { SignatureRequestToApiModel } from "../../http/encoders/signature-request";
 import { makeRequireSignatureRequest } from "../../http/decoder/signature-request";
 import { makeGetSignatureRequest } from "../cosmos/signature-request";
 import { SignatureRequest } from "../../../signature-request";
-import { toDocumentWithSasUrl } from "../storage/document-url";
 
 const grantReadAccessToDocuments = (request: SignatureRequest) =>
   pipe(

--- a/packages/io-sign/src/document-url.ts
+++ b/packages/io-sign/src/document-url.ts
@@ -1,0 +1,7 @@
+import * as TE from "fp-ts/lib/TaskEither";
+
+import { DocumentReady } from "./document";
+
+export type GetDocumentUrl = (
+  document: DocumentReady
+) => TE.TaskEither<Error, string>;

--- a/packages/io-sign/src/infra/azure/storage/document-url.ts
+++ b/packages/io-sign/src/infra/azure/storage/document-url.ts
@@ -1,13 +1,10 @@
-import * as TE from "fp-ts/lib/TaskEither";
-import * as RTE from "fp-ts/lib/ReaderTaskEither";
+import { last } from "fp-ts/lib/ReadonlyNonEmptyArray";
+import { split } from "fp-ts/lib/string";
 
 import { pipe } from "fp-ts/lib/function";
 
-import { last } from "fp-ts/lib/ReadonlyNonEmptyArray";
-
-import { split } from "fp-ts/lib/string";
-
-import { DocumentReady } from "@io-sign/io-sign/document";
+import * as RTE from "fp-ts/ReaderTaskEither";
+import { DocumentReady } from "../../../document";
 
 import {
   generateSasUrlFromBlob,
@@ -15,10 +12,10 @@ import {
   withExpireInMinutes,
   withPermissions,
   getBlobClient,
-} from "@io-sign/io-sign/infra/azure/storage/blob";
+} from "./blob";
 
 export const toDocumentWithSasUrl =
-  (permissions: string = "r", expireMminutes: number = 5) =>
+  (permissions: string = "r", expireInMinutes: number = 5) =>
   (document: DocumentReady) =>
     pipe(
       document.url,
@@ -30,7 +27,7 @@ export const toDocumentWithSasUrl =
           pipe(
             defaultBlobGenerateSasUrlOptions(),
             withPermissions(permissions),
-            withExpireInMinutes(expireMminutes)
+            withExpireInMinutes(expireInMinutes)
           )
         )
       ),
@@ -40,14 +37,10 @@ export const toDocumentWithSasUrl =
       }))
     );
 
-export type GetDocumentUrl = (
-  document: DocumentReady
-) => TE.TaskEither<Error, string>;
-
 export const getDocumentUrl =
-  (permissions: string, expireMminutes: number) => (document: DocumentReady) =>
+  (permissions: string, expireInMinutes: number) => (document: DocumentReady) =>
     pipe(
       document,
-      toDocumentWithSasUrl(permissions, expireMminutes),
+      toDocumentWithSasUrl(permissions, expireInMinutes),
       RTE.map((el) => el.url)
     );


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

⚠️ ACHTHUNG!  I'm working on a broader change to track url permissions in the domain, it will come with one of the next PRs

#### List of Changes
1. Generate SAS urls on `GetSignatureRequest` endpoint on the issuer side
2. Move common code to `@io-sign/io-sign`

<!--- Describe your changes in detail -->

#### Motivation and Context

the issuer should be able to download the signed documents from the "GetSignatureRequest" endpoint; until now the files could not be downloaded

<!--- Why is this change required? What problem does it solve? -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
