### PR TITLE
chore: [SFEQS-1350] Add maxPollingInterval for queues

### DIFF
--- a/.changeset/ten-hornets-dream.md
+++ b/.changeset/ten-hornets-dream.md
@@ -1,0 +1,6 @@
+---
+"io-func-sign-issuer": patch
+"io-func-sign-user": patch
+---
+
+Set maxPollingInterval for queues to 5 seconds

--- a/apps/io-func-sign-issuer/host.json
+++ b/apps/io-func-sign-issuer/host.json
@@ -5,7 +5,7 @@
       "routePrefix": "api/v1/sign"
     },
     "queues": {
-      "maxPollingInterval": "00:00:01.000"
+      "maxPollingInterval": "00:00:05.000"
     }
   }
 }

--- a/apps/io-func-sign-issuer/host.json
+++ b/apps/io-func-sign-issuer/host.json
@@ -3,6 +3,9 @@
   "extensions": {
     "http": {
       "routePrefix": "api/v1/sign"
+    },
+    "queues": {
+      "maxPollingInterval": "00:00:01.000"
     }
   }
 }

--- a/apps/io-func-sign-user/host.json
+++ b/apps/io-func-sign-user/host.json
@@ -5,7 +5,7 @@
       "routePrefix": "api/v1/sign"
     },
     "queues": {
-      "maxPollingInterval": "00:00:01.000"
+      "maxPollingInterval": "00:00:05.000"
     }
   }
 }

--- a/apps/io-func-sign-user/host.json
+++ b/apps/io-func-sign-user/host.json
@@ -3,6 +3,9 @@
   "extensions": {
     "http": {
       "routePrefix": "api/v1/sign"
+    },
+    "queues": {
+      "maxPollingInterval": "00:00:01.000"
     }
   }
 }


### PR DESCRIPTION
This PR sets the `maxPollingInterval` for queues to 5 seconds and try to solve the problem of waiting more than one minute for the signature request status to change from `READY` to `WAIT_FOR_SIGNATURE`.

The [queuetrigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger) implements a random exponential back-off algorithm. As a result of this if there are no messages on the queue, the SDK will back off and start polling less frequently.

`MaxPollingInterval` allows us to configure this behavior. It for when a queue remains empty, the longest period of time to wait before checking for a message to.