### PR TITLE
feat: [SFEQS-1404] Implement endpoints to use messages with attachments

### DIFF
--- a/.changeset/three-tips-occur.md
+++ b/.changeset/three-tips-occur.md
@@ -1,0 +1,6 @@
+---
+"io-func-sign-user": minor
+"@io-sign/io-sign": patch
+---
+
+Implement endpoints for third party message attachments

--- a/.changeset/tidy-colts-fetch.md
+++ b/.changeset/tidy-colts-fetch.md
@@ -1,0 +1,7 @@
+---
+"io-func-sign-issuer": patch
+"io-func-sign-user": patch
+"@io-sign/io-sign": patch
+---
+
+Moved `getDocument` and `SignatureRequestDraft` to @io-sign package

--- a/apps/io-func-sign-issuer/src/app/use-cases/validate-upload.ts
+++ b/apps/io-func-sign-issuer/src/app/use-cases/validate-upload.ts
@@ -14,6 +14,7 @@ import {
 } from "@io-sign/io-sign/document";
 
 import { NonNegativeNumber } from "@pagopa/ts-commons/lib/numbers";
+import { getDocument } from "@io-sign/io-sign/signature-request";
 import {
   DeleteUploadDocument,
   DownloadUploadDocument,
@@ -24,7 +25,6 @@ import {
   UpsertUploadMetadata,
 } from "../../upload";
 import {
-  getDocument,
   GetSignatureRequest,
   markDocumentAsReady,
   markDocumentAsRejected,

--- a/apps/io-func-sign-issuer/src/signature-request.ts
+++ b/apps/io-func-sign-issuer/src/signature-request.ts
@@ -8,7 +8,7 @@ import * as t from "io-ts";
 
 import { Signer } from "@io-sign/io-sign/signer";
 
-import { flow, pipe } from "fp-ts/lib/function";
+import { pipe } from "fp-ts/lib/function";
 import { addDays, isBefore } from "date-fns/fp";
 
 import { ActionNotAllowedError } from "@io-sign/io-sign/error";
@@ -24,26 +24,18 @@ import {
 
 import { EntityNotFoundError } from "@io-sign/io-sign/error";
 
-import { findFirst, findIndex, updateAt } from "fp-ts/lib/Array";
+import { findIndex, updateAt } from "fp-ts/lib/Array";
 import {
   SignatureRequestReady,
   SignatureRequestToBeSigned,
   SignatureRequestRejected,
   SignatureRequestSigned,
-  makeSignatureRequestVariant,
+  SignatureRequestDraft,
+  getDocument,
 } from "@io-sign/io-sign/signature-request";
 
 import { Issuer } from "@io-sign/io-sign/issuer";
 import { Dossier } from "./dossier";
-
-export const SignatureRequestDraft = makeSignatureRequestVariant(
-  "DRAFT",
-  t.type({
-    documents: t.array(Document),
-  })
-);
-
-export type SignatureRequestDraft = t.TypeOf<typeof SignatureRequestDraft>;
 
 export const SignatureRequest = t.union([
   SignatureRequestDraft,
@@ -109,12 +101,6 @@ export const withExpiryDate =
         expiresAt: expiryDate,
       }))
     );
-
-export const getDocument = (id: Document["id"]) =>
-  flow(
-    (request: SignatureRequest) => request.documents,
-    findFirst((document: Document) => document.id === id)
-  );
 
 export const replaceDocument =
   (id: Document["id"], updated: Document) => (request: SignatureRequestDraft) =>

--- a/apps/io-func-sign-issuer/src/upload.ts
+++ b/apps/io-func-sign-issuer/src/upload.ts
@@ -12,8 +12,11 @@ import { EntityNotFoundError } from "@io-sign/io-sign/error";
 import { UrlFromString } from "@pagopa/ts-commons/lib/url";
 import { Issuer } from "@io-sign/io-sign/issuer";
 
-import { SignatureRequestId } from "@io-sign/io-sign/signature-request";
-import { getDocument, SignatureRequest } from "./signature-request";
+import {
+  getDocument,
+  SignatureRequestId,
+} from "@io-sign/io-sign/signature-request";
+import { SignatureRequest } from "./signature-request";
 
 export const UploadMetadata = t.intersection([
   t.type({

--- a/apps/io-func-sign-user/GetThirdPartyMessageAttachmentContent/function.json
+++ b/apps/io-func-sign-user/GetThirdPartyMessageAttachmentContent/function.json
@@ -1,0 +1,19 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "route": "messages/{signatureRequestId}/{documentId}",
+      "methods": ["get"]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ],
+  "scriptFile": "../dist/main.js",
+  "entryPoint": "GetThirdPartyMessageAttachmentContent"
+}

--- a/apps/io-func-sign-user/GetThirdPartyMessageDetails/function.json
+++ b/apps/io-func-sign-user/GetThirdPartyMessageDetails/function.json
@@ -1,0 +1,19 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "route": "messages/{signatureRequestId}",
+      "methods": ["get"]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ],
+  "scriptFile": "../dist/main.js",
+  "entryPoint": "GetThirdPartyMessageDetails"
+}

--- a/apps/io-func-sign-user/openapi.yaml
+++ b/apps/io-func-sign-user/openapi.yaml
@@ -178,6 +178,91 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /messages/{signature_request_id}:
+    get:
+      operationId: getThirdPartyMessageDetails
+      summary: Retrieve a Third Party message with signature request documents
+      tags:
+        - Third Party Message
+      parameters:
+        - in: path
+          name: signature_request_id
+          schema:
+            type: string
+            description: Entity Id
+            format: ulid
+            example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+          required: true
+        - in: header
+          name: fiscal_code
+          schema:
+            $ref: "#/components/schemas/FiscalCode"
+          required: true
+      responses:
+        "200":
+          description: The Third Party message detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ThirdPartyMessage"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/Unexpected"
+
+  /messages/{signature_request_id}/{document_id}:
+    get:
+      operationId: getThirdPartyMessageAttachment
+      summary: Retrieve a Third Party message attachment (document)
+      tags:
+        - Third Party Message
+      parameters:
+        - in: path
+          name: signature_request_id
+          schema:
+            type: string
+            description: Signature request Id
+            format: ulid
+            example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+          required: true
+        - in: path
+          name: document_id
+          schema:
+            type: string
+            description: Document Id
+            format: ulid
+            example: 01ARZ3NDEKTSV4RRFFQ69G5FAA
+          required: true
+        - in: header
+          name: fiscal_code
+          schema:
+            $ref: "#/components/schemas/FiscalCode"
+          required: true
+      responses:
+        "200":
+          description: The Third Party message detail
+          content:
+            application/json:
+              schema:
+                type: string
+                format: binary
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/Unexpected"
+
 components:
   securitySchemes:
     FunctionsKey:
@@ -618,3 +703,30 @@ components:
         - documents
         - created_at
         - updated_at
+
+    ThirdPartyMessage:
+      type: object
+      properties:
+        attachments:
+          type: array
+          items:
+            $ref: "#/components/schemas/ThirdPartyAttachment"
+
+    ThirdPartyAttachment:
+      type: object
+      properties:
+        id:
+          type: string
+          minLength: 1
+        content_type:
+          type: string
+          minLength: 1
+        name:
+          type: string
+          minLength: 1
+        url:
+          type: string
+          minLength: 1
+      required:
+        - id
+        - url

--- a/apps/io-func-sign-user/openapi.yaml
+++ b/apps/io-func-sign-user/openapi.yaml
@@ -205,8 +205,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ThirdPartyMessage"
-        "400":
-          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
@@ -218,8 +216,8 @@ paths:
 
   /messages/{signature_request_id}/{document_id}:
     get:
-      operationId: getThirdPartyMessageAttachment
-      summary: Retrieve a Third Party message attachment (document)
+      operationId: getThirdPartyMessageAttachmentContent
+      summary: Retrieve a Third Party message attachment content (document)
       tags:
         - Third Party Message
       parameters:
@@ -250,8 +248,7 @@ paths:
           content:
             application/json:
               schema:
-                type: string
-                format: binary
+                $ref: "#/components/schemas/ThirdPartyMessageAttachmentContent"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -711,6 +708,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ThirdPartyAttachment"
+      required:
+        - attachments
 
     ThirdPartyAttachment:
       type: object
@@ -730,3 +729,7 @@ components:
       required:
         - id
         - url
+
+    ThirdPartyMessageAttachmentContent:
+      type: string
+      format: binary

--- a/apps/io-func-sign-user/openapi.yaml
+++ b/apps/io-func-sign-user/openapi.yaml
@@ -36,7 +36,7 @@ paths:
                 format: url
               description: Callback url.
           content:
-            application/pdf:
+            application/json:
               schema:
                 $ref: "#/components/schemas/FilledDocumentDetailView"
         "400":
@@ -246,7 +246,7 @@ paths:
         "200":
           description: The Third Party message detail
           content:
-            application/json:
+            application/pdf:
               schema:
                 $ref: "#/components/schemas/ThirdPartyMessageAttachmentContent"
         "400":

--- a/apps/io-func-sign-user/openapi.yaml
+++ b/apps/io-func-sign-user/openapi.yaml
@@ -36,7 +36,7 @@ paths:
                 format: url
               description: Callback url.
           content:
-            application/json:
+            application/pdf:
               schema:
                 $ref: "#/components/schemas/FilledDocumentDetailView"
         "400":

--- a/apps/io-func-sign-user/package.json
+++ b/apps/io-func-sign-user/package.json
@@ -29,6 +29,7 @@
     "@pagopa/io-functions-commons": "^26.2.1",
     "@pagopa/ts-commons": "^10.10.0",
     "crypto-js": "^4.1.1",
+    "date-fns": "^2.29.3",
     "fp-ts": "^2.13.1",
     "io-ts": "^2.2.19",
     "io-ts-types": "^0.5.19",

--- a/apps/io-func-sign-user/src/__test__/third-party-message.spec.ts
+++ b/apps/io-func-sign-user/src/__test__/third-party-message.spec.ts
@@ -9,15 +9,10 @@ import {
   WithinRangeString,
 } from "@pagopa/ts-commons/lib/strings";
 
-import { addDays } from "date-fns";
-
 import { newId } from "@io-sign/io-sign/id";
 import { SignatureRequestSigned } from "@io-sign/io-sign/signature-request";
 import { DocumentReady } from "@io-sign/io-sign/document";
-import {
-  makeGetSignedDocumentContent,
-  signedNoMoreThan90DaysAgo,
-} from "../app/use-cases/get-signed-document-content";
+import { makeGetSignedDocumentContent } from "../app/use-cases/get-signed-document-content";
 
 const documentId = newId();
 
@@ -87,27 +82,5 @@ describe("getSignedDocumentContent", () => {
     return makeRequest.then((data) => {
       expect(pipe(data, E.isRight)).toBe(false);
     });
-  });
-});
-
-describe("signedNoMoreThan90DaysAgo", () => {
-  it('should not return an error for a signature request signed 89 days ago"', () => {
-    const oldSignatureRequest = {
-      ...signatureRequest,
-      signedAt: addDays(signatureRequest.signedAt, -89),
-    };
-    expect(
-      pipe(oldSignatureRequest, signedNoMoreThan90DaysAgo, E.isRight)
-    ).toBe(true);
-  });
-
-  it('should return an error for a signature request signed 90 days ago"', () => {
-    const oldSignatureRequest = {
-      ...signatureRequest,
-      signedAt: addDays(signatureRequest.signedAt, -90),
-    };
-    expect(
-      pipe(oldSignatureRequest, signedNoMoreThan90DaysAgo, E.isRight)
-    ).toBe(false);
   });
 });

--- a/apps/io-func-sign-user/src/__test__/third-party-message.spec.ts
+++ b/apps/io-func-sign-user/src/__test__/third-party-message.spec.ts
@@ -91,7 +91,7 @@ describe("getSignedDocumentContent", () => {
 });
 
 describe("signedNoMoreThan90DaysAgo", () => {
-  it('should not return an error for a signature request signed more than 89 days ago"', () => {
+  it('should not return an error for a signature request signed 89 days ago"', () => {
     const oldSignatureRequest = {
       ...signatureRequest,
       signedAt: addDays(signatureRequest.signedAt, -89),
@@ -101,7 +101,7 @@ describe("signedNoMoreThan90DaysAgo", () => {
     ).toBe(true);
   });
 
-  it('should return an error for a signature request signed more than 90 days ago"', () => {
+  it('should return an error for a signature request signed 90 days ago"', () => {
     const oldSignatureRequest = {
       ...signatureRequest,
       signedAt: addDays(signatureRequest.signedAt, -90),

--- a/apps/io-func-sign-user/src/__test__/third-party-message.spec.ts
+++ b/apps/io-func-sign-user/src/__test__/third-party-message.spec.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "@jest/globals";
+
+import { pipe } from "fp-ts/lib/function";
+import * as E from "fp-ts/lib/Either";
+import * as TE from "fp-ts/lib/TaskEither";
+import {
+  EmailString,
+  NonEmptyString,
+  WithinRangeString,
+} from "@pagopa/ts-commons/lib/strings";
+
+import { addDays } from "date-fns";
+
+import { newId } from "@io-sign/io-sign/id";
+import { SignatureRequestSigned } from "@io-sign/io-sign/signature-request";
+import { DocumentReady } from "@io-sign/io-sign/document";
+import {
+  makeGetSignedDocumentContent,
+  signedNoMoreThan90DaysAgo,
+} from "../app/use-cases/get-signed-document-content";
+
+const documentId = newId();
+
+const signatureRequest: SignatureRequestSigned = {
+  id: newId(),
+  dossierId: newId(),
+  issuerId: newId(),
+  issuerEmail: "issuer@io-sign-mail.it" as EmailString,
+  issuerDescription: "Mocked Issuer" as NonEmptyString,
+  issuerEnvironment: "TEST",
+  signerId: newId(),
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  expiresAt: new Date(),
+  signedAt: new Date(),
+  status: "SIGNED",
+  documents: [
+    {
+      id: documentId,
+      status: "READY",
+      uploadedAt: new Date(),
+      updatedAt: new Date(),
+      url: "",
+      createdAt: new Date(),
+      metadata: {
+        title: "demo doc",
+        signatureFields: [
+          {
+            attributes: { uniqueName: "field" as NonEmptyString },
+            clause: {
+              title: "Firma demo" as WithinRangeString<5, 80>,
+              type: "REQUIRED",
+            },
+          },
+        ],
+        pdfDocumentMetadata: {
+          pages: [],
+          formFields: [],
+        },
+      },
+    },
+  ],
+};
+
+const getDocumentContent = (_document: DocumentReady) =>
+  TE.right(Buffer.alloc(0));
+
+describe("getSignedDocumentContent", () => {
+  it('should return a buffer for a specific documentId"', () => {
+    const getSignedDocumentContent =
+      makeGetSignedDocumentContent(getDocumentContent);
+
+    const makeRequest = getSignedDocumentContent(
+      signatureRequest,
+      documentId
+    )();
+    return makeRequest.then((data) => {
+      expect(pipe(data, E.isRight)).toBe(true);
+    });
+  });
+
+  it('should return an Error for a documentId that does not exist"', () => {
+    const getSignedDocumentContent =
+      makeGetSignedDocumentContent(getDocumentContent);
+
+    const makeRequest = getSignedDocumentContent(signatureRequest, newId())();
+    return makeRequest.then((data) => {
+      expect(pipe(data, E.isRight)).toBe(false);
+    });
+  });
+});
+
+describe("signedNoMoreThan90DaysAgo", () => {
+  it('should not return an error for a signature request signed more than 89 days ago"', () => {
+    const oldSignatureRequest = {
+      ...signatureRequest,
+      signedAt: addDays(signatureRequest.signedAt, -89),
+    };
+    expect(
+      pipe(oldSignatureRequest, signedNoMoreThan90DaysAgo, E.isRight)
+    ).toBe(true);
+  });
+
+  it('should return an error for a signature request signed more than 90 days ago"', () => {
+    const oldSignatureRequest = {
+      ...signatureRequest,
+      signedAt: addDays(signatureRequest.signedAt, -90),
+    };
+    expect(
+      pipe(oldSignatureRequest, signedNoMoreThan90DaysAgo, E.isRight)
+    ).toBe(false);
+  });
+});

--- a/apps/io-func-sign-user/src/app/main.ts
+++ b/apps/io-func-sign-user/src/app/main.ts
@@ -18,7 +18,7 @@ import { makeCreateSignatureRequestFunction } from "../infra/azure/functions/cre
 import { makeGetSignatureRequestFunction } from "../infra/azure/functions/get-signature-request";
 import { makeValidateSignatureFunction } from "../infra/azure/functions/validate-signature";
 import { makeGetThirdPartyMessageDetailsFunction } from "../infra/azure/functions/get-third-party-message-details";
-import { makeGetThirdPartyMessageAttachmentContentFunction } from "../infra/azure/functions/get-third-party-message-attachments";
+import { makeGetThirdPartyMessageAttachmentContentFunction } from "../infra/azure/functions/get-third-party-message-attachments-content";
 import { getConfigFromEnvironment } from "./config";
 
 const configOrError = pipe(

--- a/apps/io-func-sign-user/src/app/main.ts
+++ b/apps/io-func-sign-user/src/app/main.ts
@@ -17,6 +17,8 @@ import { makeCreateSignatureFunction } from "../infra/azure/functions/create-sig
 import { makeCreateSignatureRequestFunction } from "../infra/azure/functions/create-signature-request";
 import { makeGetSignatureRequestFunction } from "../infra/azure/functions/get-signature-request";
 import { makeValidateSignatureFunction } from "../infra/azure/functions/validate-signature";
+import { makeGetThirdPartyMessageDetailsFunction } from "../infra/azure/functions/get-third-party-message-details";
+import { makeGetThirdPartyMessageAttachmentContentFunction } from "../infra/azure/functions/get-third-party-message-attachments";
 import { getConfigFromEnvironment } from "./config";
 
 const configOrError = pipe(
@@ -144,3 +146,13 @@ export const ValidateSignature = makeValidateSignatureFunction(
   onSignedQueueClient,
   onRejectedQueueClient
 );
+
+export const GetThirdPartyMessageDetails =
+  makeGetThirdPartyMessageDetailsFunction(pdvTokenizerClient, database);
+
+export const GetThirdPartyMessageAttachmentContent =
+  makeGetThirdPartyMessageAttachmentContentFunction(
+    pdvTokenizerClient,
+    database,
+    signedContainerClient
+  );

--- a/apps/io-func-sign-user/src/app/use-cases/get-signed-document-content.ts
+++ b/apps/io-func-sign-user/src/app/use-cases/get-signed-document-content.ts
@@ -1,12 +1,12 @@
 import { pipe } from "fp-ts/lib/function";
 import * as TE from "fp-ts/lib/TaskEither";
-import * as A from "fp-ts/lib/Array";
 
 import { GetDocumentContent } from "@io-sign/io-sign/document-content";
 import { Document } from "@io-sign/io-sign/document";
 import { EntityNotFoundError } from "@io-sign/io-sign/error";
 
 import {
+  getDocument,
   SignatureRequest,
   signedNoMoreThan90DaysAgo,
 } from "../../signature-request";
@@ -20,8 +20,8 @@ export const makeGetSignedDocumentContent =
       TE.fromEither,
       TE.chain((signatureRequest) =>
         pipe(
-          signatureRequest.documents,
-          A.findFirst((document) => document.id === documentId),
+          signatureRequest,
+          getDocument(documentId),
           TE.fromOption(
             () =>
               new EntityNotFoundError(

--- a/apps/io-func-sign-user/src/app/use-cases/get-signed-document-content.ts
+++ b/apps/io-func-sign-user/src/app/use-cases/get-signed-document-content.ts
@@ -2,11 +2,12 @@ import { pipe } from "fp-ts/lib/function";
 import * as TE from "fp-ts/lib/TaskEither";
 
 import { GetDocumentContent } from "@io-sign/io-sign/document-content";
-import { Document } from "@io-sign/io-sign/document";
+import { Document, DocumentReady } from "@io-sign/io-sign/document";
 import { EntityNotFoundError } from "@io-sign/io-sign/error";
 
+import { getDocument } from "@io-sign/io-sign/signature-request";
+import { validate } from "@io-sign/io-sign/validation";
 import {
-  getDocument,
   SignatureRequest,
   signedNoMoreThan90DaysAgo,
 } from "../../signature-request";
@@ -27,6 +28,9 @@ export const makeGetSignedDocumentContent =
               new EntityNotFoundError(
                 "The specified documentID does not exists."
               )
+          ),
+          TE.chainEitherKW(
+            validate(DocumentReady, "The document must be in READY status.")
           ),
           TE.chain(getDocumentContent)
         )

--- a/apps/io-func-sign-user/src/app/use-cases/get-signed-document-content.ts
+++ b/apps/io-func-sign-user/src/app/use-cases/get-signed-document-content.ts
@@ -47,8 +47,7 @@ export const makeGetSignedDocumentContent =
       TE.chain((signatureRequest) =>
         pipe(
           signatureRequest.documents,
-          A.filter((document) => document.id === documentId),
-          A.head,
+          A.findFirst((document) => document.id === documentId),
           TE.fromOption(
             () =>
               new EntityNotFoundError(

--- a/apps/io-func-sign-user/src/app/use-cases/get-signed-document-content.ts
+++ b/apps/io-func-sign-user/src/app/use-cases/get-signed-document-content.ts
@@ -1,41 +1,15 @@
 import { pipe } from "fp-ts/lib/function";
-import * as E from "fp-ts/lib/Either";
 import * as TE from "fp-ts/lib/TaskEither";
 import * as A from "fp-ts/lib/Array";
-
-import { differenceInDays } from "date-fns";
 
 import { GetDocumentContent } from "@io-sign/io-sign/document-content";
 import { Document } from "@io-sign/io-sign/document";
 import { EntityNotFoundError } from "@io-sign/io-sign/error";
-import { SignatureRequestSigned } from "@io-sign/io-sign/signature-request";
-import { validate } from "@io-sign/io-sign/validation";
 
-import { SignatureRequest } from "../../signature-request";
-
-export const signedNoMoreThan90DaysAgo = (
-  signatureRequest: SignatureRequest
-): E.Either<Error, SignatureRequestSigned> =>
-  pipe(
-    signatureRequest,
-    validate(
-      SignatureRequestSigned,
-      "The signature request must be in SIGNED status."
-    ),
-    E.chain((signatureRequest) =>
-      pipe(
-        differenceInDays(new Date(), signatureRequest.signedAt),
-        (difference) =>
-          difference < 90
-            ? E.right(signatureRequest)
-            : E.left(
-                new EntityNotFoundError(
-                  "More than 90 days have passed since signing."
-                )
-              )
-      )
-    )
-  );
+import {
+  SignatureRequest,
+  signedNoMoreThan90DaysAgo,
+} from "../../signature-request";
 
 export const makeGetSignedDocumentContent =
   (getDocumentContent: GetDocumentContent) =>

--- a/apps/io-func-sign-user/src/app/use-cases/get-signed-document-content.ts
+++ b/apps/io-func-sign-user/src/app/use-cases/get-signed-document-content.ts
@@ -1,0 +1,61 @@
+import { pipe } from "fp-ts/lib/function";
+import * as E from "fp-ts/lib/Either";
+import * as TE from "fp-ts/lib/TaskEither";
+import * as A from "fp-ts/lib/Array";
+
+import { differenceInDays } from "date-fns";
+
+import { GetDocumentContent } from "@io-sign/io-sign/document-content";
+import { Document } from "@io-sign/io-sign/document";
+import { EntityNotFoundError } from "@io-sign/io-sign/error";
+import { SignatureRequestSigned } from "@io-sign/io-sign/signature-request";
+import { validate } from "@io-sign/io-sign/validation";
+
+import { SignatureRequest } from "../../signature-request";
+
+export const signedNoMoreThan90DaysAgo = (
+  signatureRequest: SignatureRequest
+): E.Either<Error, SignatureRequestSigned> =>
+  pipe(
+    signatureRequest,
+    validate(
+      SignatureRequestSigned,
+      "The signature request must be in SIGNED status."
+    ),
+    E.chain((signatureRequest) =>
+      pipe(
+        differenceInDays(new Date(), signatureRequest.signedAt),
+        (difference) =>
+          difference < 90
+            ? E.right(signatureRequest)
+            : E.left(
+                new EntityNotFoundError(
+                  "More than 90 days have passed since signing."
+                )
+              )
+      )
+    )
+  );
+
+export const makeGetSignedDocumentContent =
+  (getDocumentContent: GetDocumentContent) =>
+  (signatureRequest: SignatureRequest, documentId: Document["id"]) =>
+    pipe(
+      signatureRequest,
+      signedNoMoreThan90DaysAgo,
+      TE.fromEither,
+      TE.chain((signatureRequest) =>
+        pipe(
+          signatureRequest.documents,
+          A.filter((document) => document.id === documentId),
+          A.head,
+          TE.fromOption(
+            () =>
+              new EntityNotFoundError(
+                "The specified documentID does not exists."
+              )
+          ),
+          TE.chain(getDocumentContent)
+        )
+      )
+    );

--- a/apps/io-func-sign-user/src/infra/azure/functions/get-third-party-message-attachments-content.ts
+++ b/apps/io-func-sign-user/src/infra/azure/functions/get-third-party-message-attachments-content.ts
@@ -14,7 +14,7 @@ import { ContainerClient } from "@azure/storage-blob";
 
 import { PdvTokenizerClientWithApiKey } from "@io-sign/io-sign/infra/pdv-tokenizer/client";
 import { makeGetSignerByFiscalCode } from "@io-sign/io-sign/infra/pdv-tokenizer/signer";
-import { error } from "@io-sign/io-sign/infra/http/response";
+import { error, successBuffer } from "@io-sign/io-sign/infra/http/response";
 import { validate } from "@io-sign/io-sign/validation";
 import { Document, DocumentReady } from "@io-sign/io-sign/document";
 import { DocumentId } from "@io-sign/io-sign/document";
@@ -80,15 +80,7 @@ const makeGetThirdPartyMessageAttachmentContentHandler = (
     ({ signatureRequest, documentId }) =>
       getSignedDocumentContent(signatureRequest, documentId),
     error,
-    (buffer) => ({
-      // body must be of type string, but buffer.toString appends some extra characters which corrupt the final file even with byte-encoding.
-      body: buffer as unknown as string,
-      statusCode: 200,
-      headers: {
-        "Content-Type": "application/pdf",
-        "Content-Length": Buffer.byteLength(buffer).toString(),
-      },
-    })
+    successBuffer("application/pdf")
   );
 };
 

--- a/apps/io-func-sign-user/src/infra/azure/functions/get-third-party-message-attachments-content.ts
+++ b/apps/io-func-sign-user/src/infra/azure/functions/get-third-party-message-attachments-content.ts
@@ -81,7 +81,7 @@ const makeGetThirdPartyMessageAttachmentContentHandler = (
       getSignedDocumentContent(signatureRequest, documentId),
     error,
     (buffer) => ({
-      // body is of type string, but buffer.toString appends some extra characters which corrupt the final file even with byte-encoding.
+      // body must be of type string, but buffer.toString appends some extra characters which corrupt the final file even with byte-encoding.
       body: buffer as unknown as string,
       statusCode: 200,
       headers: {

--- a/apps/io-func-sign-user/src/infra/azure/functions/get-third-party-message-attachments.ts
+++ b/apps/io-func-sign-user/src/infra/azure/functions/get-third-party-message-attachments.ts
@@ -1,0 +1,98 @@
+import { flow, pipe } from "fp-ts/lib/function";
+
+import { sequenceS } from "fp-ts/lib/Apply";
+import * as RTE from "fp-ts/lib/ReaderTaskEither";
+import * as TE from "fp-ts/lib/TaskEither";
+import * as E from "fp-ts/lib/Either";
+
+import * as azure from "@pagopa/handler-kit/lib/azure";
+import { createHandler } from "@pagopa/handler-kit";
+import { HttpRequest, path } from "@pagopa/handler-kit/lib/http";
+
+import { Database } from "@azure/cosmos";
+import { ContainerClient } from "@azure/storage-blob";
+
+import { PdvTokenizerClientWithApiKey } from "@io-sign/io-sign/infra/pdv-tokenizer/client";
+import { makeGetSignerByFiscalCode } from "@io-sign/io-sign/infra/pdv-tokenizer/signer";
+import { error } from "@io-sign/io-sign/infra/http/response";
+import { validate } from "@io-sign/io-sign/validation";
+import { Document, DocumentReady } from "@io-sign/io-sign/document";
+import { DocumentId } from "@io-sign/io-sign/document";
+import { GetDocumentContent } from "@io-sign/io-sign/document-content";
+import { getDocumentContent } from "@io-sign/io-sign/infra/azure/storage/document-content";
+
+import { makeGetSignatureRequest } from "../cosmos/signature-request";
+import { makeRequireSignatureRequestByFiscalCode } from "../../http/decoder/signature-request";
+
+import { SignatureRequest } from "../../../signature-request";
+import { makeGetSignedDocumentContent } from "../../../app/use-cases/get-signed-document-content";
+
+export type GetAttachmentPayload = {
+  signatureRequest: SignatureRequest;
+  documentId: Document["id"];
+};
+
+const makeGetThirdPartyMessageAttachmentContentHandler = (
+  pdvTokenizerClientWithApiKey: PdvTokenizerClientWithApiKey,
+  db: Database,
+  signedContainerClient: ContainerClient
+) => {
+  const getSignerByFiscalCode = makeGetSignerByFiscalCode(
+    pdvTokenizerClientWithApiKey
+  );
+
+  const getSignatureRequest = makeGetSignatureRequest(db);
+
+  const requireDocumentIdFromPath = flow(
+    path("documentId"),
+    E.fromOption(() => new Error(`missing "documentId" in path`)),
+    E.chainW(validate(DocumentId, `invalid "documentId" supplied`))
+  );
+
+  const getDocumenContent: GetDocumentContent = (document: DocumentReady) =>
+    pipe(document, getDocumentContent)(signedContainerClient);
+
+  const getSignedDocumentContent =
+    makeGetSignedDocumentContent(getDocumenContent);
+
+  const requireGetAttachmentPayload: RTE.ReaderTaskEither<
+    HttpRequest,
+    Error,
+    GetAttachmentPayload
+  > = sequenceS(RTE.ApplyPar)({
+    signatureRequest: flow(
+      makeRequireSignatureRequestByFiscalCode(
+        getSignatureRequest,
+        getSignerByFiscalCode
+      )
+    ),
+    documentId: RTE.fromReaderEither(requireDocumentIdFromPath),
+  });
+
+  const decodeHttpRequest = flow(
+    azure.fromHttpRequest,
+    TE.fromEither,
+    TE.chain(requireGetAttachmentPayload)
+  );
+
+  return createHandler(
+    decodeHttpRequest,
+    ({ signatureRequest, documentId }) =>
+      getSignedDocumentContent(signatureRequest, documentId),
+    error,
+    (buffer) => ({
+      // body is of type string, but buffer.toString appends some extra characters which corrupt the final file even with byte-encoding.
+      body: buffer as unknown as string,
+      statusCode: 200,
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Length": Buffer.byteLength(buffer).toString(),
+      },
+    })
+  );
+};
+
+export const makeGetThirdPartyMessageAttachmentContentFunction = flow(
+  makeGetThirdPartyMessageAttachmentContentHandler,
+  azure.unsafeRun
+);

--- a/apps/io-func-sign-user/src/infra/azure/functions/get-third-party-message-details.ts
+++ b/apps/io-func-sign-user/src/infra/azure/functions/get-third-party-message-details.ts
@@ -14,7 +14,7 @@ import { makeGetSignatureRequest } from "../cosmos/signature-request";
 import { makeRequireSignatureRequestByFiscalCode } from "../../http/decoder/signature-request";
 import { SignatureRequestToThirdPartyMessage } from "../../http/encoders/signature-request";
 import { ThirdPartyMessage } from "../../http/models/ThirdPartyMessage";
-import { signedNoMoreThan90DaysAgo } from "../../../app/use-cases/get-signed-document-content";
+import { signedNoMoreThan90DaysAgo } from "../../../signature-request";
 
 const makeGetThirdPartyMessageDetailsHandler = (
   pdvTokenizerClientWithApiKey: PdvTokenizerClientWithApiKey,

--- a/apps/io-func-sign-user/src/infra/azure/functions/get-third-party-message-details.ts
+++ b/apps/io-func-sign-user/src/infra/azure/functions/get-third-party-message-details.ts
@@ -1,0 +1,57 @@
+import { flow, pipe } from "fp-ts/lib/function";
+import * as TE from "fp-ts/lib/TaskEither";
+
+import * as azure from "@pagopa/handler-kit/lib/azure";
+import { createHandler } from "@pagopa/handler-kit";
+
+import { Database } from "@azure/cosmos";
+
+import { PdvTokenizerClientWithApiKey } from "@io-sign/io-sign/infra/pdv-tokenizer/client";
+import { makeGetSignerByFiscalCode } from "@io-sign/io-sign/infra/pdv-tokenizer/signer";
+import { error, success } from "@io-sign/io-sign/infra/http/response";
+
+import { makeGetSignatureRequest } from "../cosmos/signature-request";
+import { makeRequireSignatureRequestByFiscalCode } from "../../http/decoder/signature-request";
+import { SignatureRequestToThirdPartyMessage } from "../../http/encoders/signature-request";
+import { ThirdPartyMessage } from "../../http/models/ThirdPartyMessage";
+import { signedNoMoreThan90DaysAgo } from "../../../app/use-cases/get-signed-document-content";
+
+const makeGetThirdPartyMessageDetailsHandler = (
+  pdvTokenizerClientWithApiKey: PdvTokenizerClientWithApiKey,
+  db: Database
+) => {
+  const getSignerByFiscalCode = makeGetSignerByFiscalCode(
+    pdvTokenizerClientWithApiKey
+  );
+
+  const getSignatureRequest = makeGetSignatureRequest(db);
+
+  const requireSignatureRequestByFiscalCode =
+    makeRequireSignatureRequestByFiscalCode(
+      getSignatureRequest,
+      getSignerByFiscalCode
+    );
+
+  const decodeHttpRequest = flow(
+    azure.fromHttpRequest,
+    TE.fromEither,
+    TE.chain(requireSignatureRequestByFiscalCode)
+  );
+
+  const encodeHttpSuccessResponse = flow(
+    SignatureRequestToThirdPartyMessage.encode,
+    success(ThirdPartyMessage)
+  );
+
+  return createHandler(
+    decodeHttpRequest,
+    (request) => pipe(request, signedNoMoreThan90DaysAgo, TE.fromEither),
+    error,
+    encodeHttpSuccessResponse
+  );
+};
+
+export const makeGetThirdPartyMessageDetailsFunction = flow(
+  makeGetThirdPartyMessageDetailsHandler,
+  azure.unsafeRun
+);

--- a/apps/io-func-sign-user/src/infra/http/decoder/fiscal-code.ts
+++ b/apps/io-func-sign-user/src/infra/http/decoder/fiscal-code.ts
@@ -12,6 +12,9 @@ import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
 export const requireFiscalCode = (req: HttpRequest) =>
   pipe(
     req,
+    /* This header name (not in `kebab-case`) comes from the specification of messages with attachments that we must respect.
+     * https://github.com/pagopa/io-backend/blob/c7257c946b99830fe8c052d4cc0d4dc78b000d51/openapi/consumed/api-third-party.yaml#L94
+     */
     header("fiscal_code"),
     E.fromOption(
       () => new HttpBadRequestError("Missing fiscal_code in header")

--- a/apps/io-func-sign-user/src/infra/http/decoder/fiscal-code.ts
+++ b/apps/io-func-sign-user/src/infra/http/decoder/fiscal-code.ts
@@ -1,0 +1,20 @@
+import { header, HttpRequest } from "@pagopa/handler-kit/lib/http";
+
+import { validate } from "@io-sign/io-sign/validation";
+
+import { pipe } from "fp-ts/lib/function";
+
+import * as E from "fp-ts/lib/Either";
+
+import { HttpBadRequestError } from "@io-sign/io-sign/infra/http/errors";
+import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
+
+export const requireFiscalCode = (req: HttpRequest) =>
+  pipe(
+    req,
+    header("fiscal_code"),
+    E.fromOption(
+      () => new HttpBadRequestError("Missing fiscal_code in header")
+    ),
+    E.chainW(validate(FiscalCode, "Invalid fiscal code"))
+  );

--- a/apps/io-func-sign-user/src/infra/http/decoder/signature-request.ts
+++ b/apps/io-func-sign-user/src/infra/http/decoder/signature-request.ts
@@ -24,6 +24,9 @@ import {
 import { requireSigner } from "./signer";
 import { requireFiscalCode } from "./fiscal-code";
 
+const signatureRequestNotFoundError = () =>
+  new EntityNotFoundError("The specified Signature Request does not exists.");
+
 export const makeRequireSignatureRequest = (
   getSignatureRequest: GetSignatureRequest
 ): RTE.ReaderTaskEither<HttpRequest, Error, SignatureRequest> =>
@@ -36,14 +39,7 @@ export const makeRequireSignatureRequest = (
     RTE.chainTaskEitherK(({ signer, signatureRequestId }) =>
       pipe(signer.id, getSignatureRequest(signatureRequestId))
     ),
-    RTE.chainW(
-      RTE.fromOption(
-        () =>
-          new EntityNotFoundError(
-            "The specified Signature Request does not exists."
-          )
-      )
-    )
+    RTE.chainW(RTE.fromOption(signatureRequestNotFoundError))
   );
 
 export const makeRequireSignatureRequestByFiscalCode = (
@@ -70,13 +66,5 @@ export const makeRequireSignatureRequestByFiscalCode = (
         TE.chain(getSignatureRequest(signatureRequestId))
       )
     ),
-    RTE.chainW(
-      RTE.fromOption(
-        // eslint-disable-next-line sonarjs/no-identical-functions
-        () =>
-          new EntityNotFoundError(
-            "The specified Signature Request does not exists."
-          )
-      )
-    )
+    RTE.chainW(RTE.fromOption(signatureRequestNotFoundError))
   );

--- a/apps/io-func-sign-user/src/infra/http/decoder/signature-request.ts
+++ b/apps/io-func-sign-user/src/infra/http/decoder/signature-request.ts
@@ -4,6 +4,7 @@ import { HttpRequest, path } from "@pagopa/handler-kit/lib/http";
 import { sequenceS } from "fp-ts/lib/Apply";
 
 import * as RTE from "fp-ts/lib/ReaderTaskEither";
+import * as TE from "fp-ts/lib/TaskEither";
 import * as E from "fp-ts/lib/Either";
 import * as RE from "fp-ts/lib/ReaderEither";
 import { flow, pipe } from "fp-ts/lib/function";
@@ -15,11 +16,13 @@ const requireSignatureRequestIdFromPath = flow(
 );
 
 import { EntityNotFoundError } from "@io-sign/io-sign/error";
+import { GetSignerByFiscalCode } from "@io-sign/io-sign/signer";
 import {
   GetSignatureRequest,
   SignatureRequest,
 } from "../../../signature-request";
 import { requireSigner } from "./signer";
+import { requireFiscalCode } from "./fiscal-code";
 
 export const makeRequireSignatureRequest = (
   getSignatureRequest: GetSignatureRequest
@@ -35,6 +38,41 @@ export const makeRequireSignatureRequest = (
     ),
     RTE.chainW(
       RTE.fromOption(
+        () =>
+          new EntityNotFoundError(
+            "The specified Signature Request does not exists."
+          )
+      )
+    )
+  );
+
+export const makeRequireSignatureRequestByFiscalCode = (
+  getSignatureRequest: GetSignatureRequest,
+  getSignerByFiscalCode: GetSignerByFiscalCode
+): RTE.ReaderTaskEither<HttpRequest, Error, SignatureRequest> =>
+  pipe(
+    sequenceS(RE.Apply)({
+      fiscalCode: flow(requireFiscalCode),
+      signatureRequestId: requireSignatureRequestIdFromPath,
+    }),
+    RTE.fromReaderEither,
+    RTE.chainTaskEitherK(({ fiscalCode, signatureRequestId }) =>
+      pipe(
+        fiscalCode,
+        getSignerByFiscalCode,
+        TE.chain(
+          TE.fromOption(
+            () =>
+              new EntityNotFoundError("The specified signer does not exists.")
+          )
+        ),
+        TE.map((signer) => signer.id),
+        TE.chain(getSignatureRequest(signatureRequestId))
+      )
+    ),
+    RTE.chainW(
+      RTE.fromOption(
+        // eslint-disable-next-line sonarjs/no-identical-functions
         () =>
           new EntityNotFoundError(
             "The specified Signature Request does not exists."

--- a/apps/io-func-sign-user/src/infra/http/decoder/signature-request.ts
+++ b/apps/io-func-sign-user/src/infra/http/decoder/signature-request.ts
@@ -48,7 +48,7 @@ export const makeRequireSignatureRequestByFiscalCode = (
 ): RTE.ReaderTaskEither<HttpRequest, Error, SignatureRequest> =>
   pipe(
     sequenceS(RE.Apply)({
-      fiscalCode: flow(requireFiscalCode),
+      fiscalCode: requireFiscalCode,
       signatureRequestId: requireSignatureRequestIdFromPath,
     }),
     RTE.fromReaderEither,

--- a/apps/io-func-sign-user/src/infra/http/encoders/signature-request.ts
+++ b/apps/io-func-sign-user/src/infra/http/encoders/signature-request.ts
@@ -1,9 +1,15 @@
 import * as E from "io-ts/lib/Encoder";
 
+import { SignatureRequestSigned } from "@io-sign/io-sign/signature-request";
+import { pipe } from "fp-ts/lib/function";
+import * as A from "fp-ts/lib/Array";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import {
   SignatureRequestDetailView as SignatureRequestApiModel,
   StatusEnum as SignatureRequestStatusEnum,
 } from "../models/SignatureRequestDetailView";
+
+import { ThirdPartyMessage as ThirdPartyMessageApiModel } from "../models/ThirdPartyMessage";
 
 import { SignatureRequest } from "../../../signature-request";
 
@@ -70,4 +76,21 @@ export const SignatureRequestToApiModel: E.Encoder<
       }
     }
   },
+};
+
+export const SignatureRequestToThirdPartyMessage: E.Encoder<
+  ThirdPartyMessageApiModel,
+  SignatureRequestSigned
+> = {
+  encode: ({ documents }) => ({
+    attachments: pipe(
+      documents,
+      A.map((document) => ({
+        id: document.id,
+        content_type: "application/pdf" as NonEmptyString,
+        name: document.metadata.title,
+        url: document.id,
+      }))
+    ),
+  }),
 };

--- a/apps/io-func-sign-user/src/signature-request.ts
+++ b/apps/io-func-sign-user/src/signature-request.ts
@@ -5,6 +5,8 @@ import {
   SignatureRequestWaitForQtsp,
 } from "@io-sign/io-sign/signature-request";
 
+import { Document } from "@io-sign/io-sign/document";
+
 import { Id } from "@io-sign/io-sign/id";
 import * as E from "fp-ts/lib/Either";
 import * as TE from "fp-ts/lib/TaskEither";
@@ -12,12 +14,13 @@ import * as O from "fp-ts/lib/Option";
 import { differenceInDays } from "date-fns";
 
 import * as t from "io-ts";
-import { pipe } from "fp-ts/lib/function";
+import { flow, pipe } from "fp-ts/lib/function";
 import {
   ActionNotAllowedError,
   EntityNotFoundError,
 } from "@io-sign/io-sign/error";
 import { validate } from "@io-sign/io-sign/validation";
+import { findFirst } from "fp-ts/lib/Array";
 
 export const SignatureRequest = t.union([
   SignatureRequestToBeSigned,
@@ -208,4 +211,10 @@ export const signedNoMoreThan90DaysAgo = (
               )
       )
     )
+  );
+
+export const getDocument = (id: Document["id"]) =>
+  flow(
+    (request: SignatureRequest) => request.documents,
+    findFirst((document: Document) => document.id === id)
   );

--- a/apps/io-func-sign-user/src/signature-request.ts
+++ b/apps/io-func-sign-user/src/signature-request.ts
@@ -5,8 +5,6 @@ import {
   SignatureRequestWaitForQtsp,
 } from "@io-sign/io-sign/signature-request";
 
-import { Document } from "@io-sign/io-sign/document";
-
 import { Id } from "@io-sign/io-sign/id";
 import * as E from "fp-ts/lib/Either";
 import * as TE from "fp-ts/lib/TaskEither";
@@ -14,13 +12,12 @@ import * as O from "fp-ts/lib/Option";
 import { differenceInDays } from "date-fns";
 
 import * as t from "io-ts";
-import { flow, pipe } from "fp-ts/lib/function";
+import { pipe } from "fp-ts/lib/function";
 import {
   ActionNotAllowedError,
   EntityNotFoundError,
 } from "@io-sign/io-sign/error";
 import { validate } from "@io-sign/io-sign/validation";
-import { findFirst } from "fp-ts/lib/Array";
 
 export const SignatureRequest = t.union([
   SignatureRequestToBeSigned,
@@ -211,10 +208,4 @@ export const signedNoMoreThan90DaysAgo = (
               )
       )
     )
-  );
-
-export const getDocument = (id: Document["id"]) =>
-  flow(
-    (request: SignatureRequest) => request.documents,
-    findFirst((document: Document) => document.id === id)
   );

--- a/packages/io-sign/src/document-content.ts
+++ b/packages/io-sign/src/document-content.ts
@@ -1,0 +1,7 @@
+import * as TE from "fp-ts/lib/TaskEither";
+
+import { DocumentReady } from "./document";
+
+export type GetDocumentContent = (
+  document: DocumentReady
+) => TE.TaskEither<Error, Buffer>;

--- a/packages/io-sign/src/infra/azure/storage/blob.ts
+++ b/packages/io-sign/src/infra/azure/storage/blob.ts
@@ -63,3 +63,13 @@ export const generateSasUrlFromBlob = (options: BlobGenerateSasUrlOptions) =>
       )
     )
   );
+
+export const downloadContentFromBlob = pipe(
+  RTE.ask<BlobClient>(),
+  RTE.chainTaskEitherK((blobClient) =>
+    TE.tryCatch(
+      () => blobClient.downloadToBuffer(),
+      () => new Error("Unable to download content for the specified Blob.")
+    )
+  )
+);

--- a/packages/io-sign/src/infra/azure/storage/document-content.ts
+++ b/packages/io-sign/src/infra/azure/storage/document-content.ts
@@ -1,0 +1,18 @@
+import { last } from "fp-ts/lib/ReadonlyNonEmptyArray";
+import { split } from "fp-ts/lib/string";
+
+import { pipe } from "fp-ts/lib/function";
+
+import * as RTE from "fp-ts/ReaderTaskEither";
+import { DocumentReady } from "../../../document";
+
+import { getBlobClient, downloadContentFromBlob } from "./blob";
+
+export const getDocumentContent = (document: DocumentReady) =>
+  pipe(
+    document.url,
+    split("/"),
+    last,
+    getBlobClient,
+    RTE.chainTaskEitherK(downloadContentFromBlob)
+  );

--- a/packages/io-sign/src/signature-request.ts
+++ b/packages/io-sign/src/signature-request.ts
@@ -3,11 +3,14 @@ import * as t from "io-ts";
 import { IsoDateFromString } from "@pagopa/ts-commons/lib/dates";
 import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 
+import { flow } from "fp-ts/lib/function";
+import { findFirst } from "fp-ts/lib/Array";
 import { Id } from "./id";
 import { Signer } from "./signer";
 import { DocumentReady } from "./document";
 import { Notification } from "./notification";
 import { Issuer, IssuerEnvironment } from "./issuer";
+import { Document } from "./document";
 
 const SignatureRequest = t.type({
   id: Id,
@@ -36,6 +39,15 @@ export const makeSignatureRequestVariant = <S extends string, A, O>(
     }),
     codec,
   ]);
+
+export const SignatureRequestDraft = makeSignatureRequestVariant(
+  "DRAFT",
+  t.type({
+    documents: t.array(Document),
+  })
+);
+
+export type SignatureRequestDraft = t.TypeOf<typeof SignatureRequestDraft>;
 
 export const SignatureRequestReady = makeSignatureRequestVariant(
   "READY",
@@ -113,3 +125,17 @@ export const SignatureRequestRejected = makeSignatureRequestVariant(
 export type SignatureRequestRejected = t.TypeOf<
   typeof SignatureRequestRejected
 >;
+
+export const getDocument = (id: Document["id"]) =>
+  flow(
+    (
+      request:
+        | SignatureRequestDraft
+        | SignatureRequestSigned
+        | SignatureRequestReady
+        | SignatureRequestToBeSigned
+        | SignatureRequestWaitForQtsp
+        | SignatureRequestRejected
+    ) => request.documents,
+    findFirst((document: Document) => document.id === id)
+  );

--- a/yarn.lock
+++ b/yarn.lock
@@ -5428,6 +5428,7 @@ __metadata:
     "@types/jsrsasign": ^10.5.4
     azure-functions-core-tools: ^4.0.4895
     crypto-js: ^4.1.1
+    date-fns: ^2.29.3
     eslint: ^8.28.0
     fp-ts: ^2.13.1
     io-ts: ^2.2.19


### PR DESCRIPTION
This PR implements the 2 endpoints needed to use messages with attachments.

In particular, the following endpoints have been implemented:
- `/messages/{signatureRequestId}` which allows you to obtain the list of documents (attachments) associated with a signature request.
- `/messages/{signatureRequestId}/{documentId}` Which allows you to obtain the content of the single document in the `application/pdf` format

#### How Has This Been Tested?
Tested locally with cloud resources

#### Checklist:
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
