### PR TITLE
fix: [SFEQS-1431] Add filename extension to ThirdPartyMessageApiModel

### DIFF
--- a/.changeset/khaki-otters-mix.md
+++ b/.changeset/khaki-otters-mix.md
@@ -1,0 +1,5 @@
+---
+"io-func-sign-user": patch
+---
+
+Add filename extension to ThirdPartyMessageApiModel

--- a/apps/io-func-sign-user/src/infra/http/encoders/signature-request.ts
+++ b/apps/io-func-sign-user/src/infra/http/encoders/signature-request.ts
@@ -88,7 +88,7 @@ export const SignatureRequestToThirdPartyMessage: E.Encoder<
       A.map((document) => ({
         id: document.id,
         content_type: "application/pdf" as NonEmptyString,
-        name: document.metadata.title,
+        name: `${document.metadata.title}.pdf` as NonEmptyString,
         url: document.id,
       }))
     ),

--- a/apps/io-func-sign-user/src/infra/http/encoders/signature-request.ts
+++ b/apps/io-func-sign-user/src/infra/http/encoders/signature-request.ts
@@ -3,6 +3,8 @@ import * as E from "io-ts/lib/Encoder";
 import { SignatureRequestSigned } from "@io-sign/io-sign/signature-request";
 import { pipe } from "fp-ts/lib/function";
 import * as A from "fp-ts/lib/Array";
+import * as S from "fp-ts/lib/string";
+
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import {
   SignatureRequestDetailView as SignatureRequestApiModel,
@@ -88,7 +90,9 @@ export const SignatureRequestToThirdPartyMessage: E.Encoder<
       A.map((document) => ({
         id: document.id,
         content_type: "application/pdf" as NonEmptyString,
-        name: `${document.metadata.title}.pdf` as NonEmptyString,
+        name: pipe(document.metadata.title, S.endsWith(".pdf"))
+          ? document.metadata.title
+          : `${document.metadata.title}.pdf`,
         url: document.id,
       }))
     ),

--- a/apps/io-func-sign-user/src/infra/http/encoders/signature-request.ts
+++ b/apps/io-func-sign-user/src/infra/http/encoders/signature-request.ts
@@ -17,6 +17,11 @@ import { SignatureRequest } from "../../../signature-request";
 
 import { DocumentReadyToDetailView } from "./document";
 
+const addPdfExtension = (fileName: NonEmptyString) =>
+  pipe(fileName, S.endsWith(".pdf"))
+    ? fileName
+    : (`${fileName}.pdf` as NonEmptyString);
+
 export const SignatureRequestToApiModel: E.Encoder<
   SignatureRequestApiModel,
   SignatureRequest
@@ -90,9 +95,7 @@ export const SignatureRequestToThirdPartyMessage: E.Encoder<
       A.map((document) => ({
         id: document.id,
         content_type: "application/pdf" as NonEmptyString,
-        name: pipe(document.metadata.title, S.endsWith(".pdf"))
-          ? document.metadata.title
-          : `${document.metadata.title}.pdf`,
+        name: addPdfExtension(document.metadata.title),
         url: document.id,
       }))
     ),


### PR DESCRIPTION
Add `.pdf` extension to filename in third party message attachments.