### PR TITLE
feat(user): [SFEQS-1479] Lollipop integration mock   🍭

### DIFF
--- a/.changeset/six-dolphins-march.md
+++ b/.changeset/six-dolphins-march.md
@@ -1,0 +1,5 @@
+---
+"io-func-sign-user": patch
+---
+
+Added lollipop mock

--- a/apps/io-func-sign-user/package.json
+++ b/apps/io-func-sign-user/package.json
@@ -33,6 +33,7 @@
     "fp-ts": "^2.13.1",
     "io-ts": "^2.2.19",
     "io-ts-types": "^0.5.19",
+    "jose": "^4.13.1",
     "jsrsasign": "^10.6.1",
     "monocle-ts": "^2.3.13",
     "newtype-ts": "^0.3.5"
@@ -45,6 +46,7 @@
     "@rushstack/eslint-patch": "^1.2.0",
     "@types/crypto-js": "^4.1.1",
     "@types/jsrsasign": "^10.5.4",
+    "@types/node-jose": "^1.1.10",
     "azure-functions-core-tools": "^4.0.4895",
     "eslint": "^8.28.0",
     "jest": "^29.3.1",

--- a/apps/io-func-sign-user/src/app/use-cases/__mocks__/qtsp.ts
+++ b/apps/io-func-sign-user/src/app/use-cases/__mocks__/qtsp.ts
@@ -38,6 +38,9 @@ type LollipopMock = {
   signatureParams: string;
 };
 
+const utfToBase64 = (value: string) =>
+  Buffer.from(value, "utf-8").toString("base64");
+
 export const convertPemToJwkPublicKey = (publicKey: string) =>
   pipe(
     TE.tryCatch(() => jose.importSPKI(publicKey, CRYPTO_ALG), E.toError),
@@ -50,7 +53,7 @@ export const convertPemToBase64JwkPublicKey = (publicKey: string) =>
   pipe(
     convertPemToJwkPublicKey(publicKey),
     TE.map(JSON.stringify),
-    TE.map((jwkString) => Buffer.from(jwkString, "utf-8").toString("base64"))
+    TE.map(utfToBase64)
   );
 
 const mockSignatureParams = (
@@ -148,7 +151,7 @@ export const mockSpidAssertion =
               "INRESPONSETO_FIELD",
               `sha256-${publicKeyThumbprint}`
             ),
-          (decodedSaml) => Buffer.from(decodedSaml, "utf-8").toString("base64")
+          utfToBase64
         );
       }),
       TE.chainEitherKW(
@@ -236,6 +239,5 @@ export const mockSignatureInput = (
 ): NonEmptyString =>
   pipe(
     `sig1=("content-digest" "content-type" "x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url");created=${getCurrentTimeStamp()};nonce="${MOCKED_NONCE}";alg="${LOLLIPOP_ALG}";keyid="${MOCK_KEY_ID}",sig2=${tosSignatureInput},sig3=${signSignatureInput}`,
-    (signatureInput) =>
-      Buffer.from(signatureInput, "utf-8").toString("base64") as NonEmptyString
+    (signatureInput) => utfToBase64(signatureInput) as NonEmptyString
   );

--- a/apps/io-func-sign-user/src/app/use-cases/__mocks__/qtsp.ts
+++ b/apps/io-func-sign-user/src/app/use-cases/__mocks__/qtsp.ts
@@ -75,8 +75,8 @@ const sign = (value: string) =>
     crypto.createHash("sha256").update(value).digest("hex"),
     E.fromNullable(new Error("Unable to create hash during signature")),
     E.map((hexValue) => ec.signHex(hexValue, prvhex)),
-    E.map((signature) => cryptoJS.enc.Hex.parse(signature)),
-    E.map((signatureHex) => cryptoJS.enc.Base64.stringify(signatureHex))
+    E.map(cryptoJS.enc.Hex.parse),
+    E.map(cryptoJS.enc.Base64.stringify)
   );
 
 const signatureSequence = (lollipop: LollipopMock) =>

--- a/apps/io-func-sign-user/src/app/use-cases/__mocks__/qtsp.ts
+++ b/apps/io-func-sign-user/src/app/use-cases/__mocks__/qtsp.ts
@@ -49,7 +49,7 @@ export const convertPemToJwkPublicKey = (publicKey: string) =>
 export const convertPemToBase64JwkPublicKey = (publicKey: string) =>
   pipe(
     convertPemToJwkPublicKey(publicKey),
-    TE.map((jwk) => JSON.stringify(jwk)),
+    TE.map(JSON.stringify),
     TE.map((jwkString) => Buffer.from(jwkString, "utf-8").toString("base64"))
   );
 

--- a/apps/io-func-sign-user/src/app/use-cases/__mocks__/qtsp.ts
+++ b/apps/io-func-sign-user/src/app/use-cases/__mocks__/qtsp.ts
@@ -65,7 +65,7 @@ const mockValueToSign =
   (hexValue: string): LollipopMock => {
     const signatureParams = mockSignatureParams(headerName, timestamp, nonce);
     return {
-      signatureParams: mockSignatureParams(headerName, timestamp, nonce),
+      signatureParams,
       value: `"${headerName}": ${hexValue}\n"@signature-params": ${signatureParams}`,
     };
   };

--- a/apps/io-func-sign-user/src/app/use-cases/__mocks__/qtsp.ts
+++ b/apps/io-func-sign-user/src/app/use-cases/__mocks__/qtsp.ts
@@ -22,6 +22,7 @@ const SIGN_CHALLENGE_HEADER_NAME = "x-pagopa-lollipop-custom-sign-challenge";
 const MOCKED_NONCE = "mockedNonce";
 const CRYPTO_ALG = "ES256";
 const CRYPTO_CURVE = "P-256";
+const LOLLIPOP_ALG = "ecdsa-p256-sha256";
 
 const ec = new rs.KJUR.crypto.ECDSA({ curve: CRYPTO_CURVE });
 const kp1 = rs.KEYUTIL.generateKeypair("EC", CRYPTO_CURVE);
@@ -57,7 +58,7 @@ const mockSignatureParams = (
   timestamp: number,
   nonce: string
 ) =>
-  `("${headerName}");created=${timestamp};nonce="${nonce}";alg="ecdsa-p256-sha256";keyid="${MOCK_KEY_ID}"`;
+  `("${headerName}");created=${timestamp};nonce="${nonce}";alg="${LOLLIPOP_ALG}";keyid="${MOCK_KEY_ID}"`;
 
 const mockValueToSign =
   (headerName: string, timestamp: number, nonce: string) =>
@@ -234,7 +235,7 @@ export const mockSignatureInput = (
   signSignatureInput: string
 ): NonEmptyString =>
   pipe(
-    `sig1=("content-digest" "content-type" "x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url");created=${getCurrentTimeStamp()};nonce="${MOCKED_NONCE}";alg="ecdsa-p256-sha256";keyid="${MOCK_KEY_ID}",sig2=${tosSignatureInput},sig3=${signSignatureInput}`,
+    `sig1=("content-digest" "content-type" "x-pagopa-lollipop-original-method" "x-pagopa-lollipop-original-url");created=${getCurrentTimeStamp()};nonce="${MOCKED_NONCE}";alg="${LOLLIPOP_ALG}";keyid="${MOCK_KEY_ID}",sig2=${tosSignatureInput},sig3=${signSignatureInput}`,
     (signatureInput) =>
       Buffer.from(signatureInput, "utf-8").toString("base64") as NonEmptyString
   );

--- a/apps/io-func-sign-user/src/app/use-cases/create-signature.ts
+++ b/apps/io-func-sign-user/src/app/use-cases/create-signature.ts
@@ -34,11 +34,12 @@ import {
 } from "../../signature-request";
 
 import {
+  convertPemToBase64JwkPublicKey,
   mockSignature,
   mockSignatureInput,
   mockSpidAssertion,
   mockTosSignature,
-  publicKeyToBase64,
+  pemPublicKey,
 } from "./__mocks__/qtsp";
 
 export const CreateSignaturePayload = t.type({
@@ -147,7 +148,7 @@ export const makeCreateSignature =
 
     const createSignatureRequest = pipe(
       sequenceS(TE.ApplicativeSeq)({
-        publicKey: publicKeyToBase64(),
+        publicKey: convertPemToBase64JwkPublicKey(pemPublicKey),
         fiscalCode: pipe(
           signer.id,
           getFiscalCodeBySignerId,

--- a/apps/io-func-sign-user/src/infra/azure/functions/create-signature.ts
+++ b/apps/io-func-sign-user/src/infra/azure/functions/create-signature.ts
@@ -154,7 +154,7 @@ const makeCreateSignatureHandler = (
   return createHandler(
     decodeHttpRequest,
     createSignature,
-    error,
+    console.error,
     encodeHttpSuccessResponse
   );
 };

--- a/apps/io-func-sign-user/src/infra/azure/functions/create-signature.ts
+++ b/apps/io-func-sign-user/src/infra/azure/functions/create-signature.ts
@@ -154,7 +154,7 @@ const makeCreateSignatureHandler = (
   return createHandler(
     decodeHttpRequest,
     createSignature,
-    console.error,
+    error,
     encodeHttpSuccessResponse
   );
 };

--- a/apps/io-func-sign-user/src/infra/namirial/encoders/signature-request.ts
+++ b/apps/io-func-sign-user/src/infra/namirial/encoders/signature-request.ts
@@ -76,6 +76,7 @@ export const QtspCreateSignatureToApiModel: E.Encoder<
     tosSignature,
     signature,
     documentsToSign,
+    signatureInput,
   }) => ({
     fiscal_code: fiscalCode,
     public_key: publicKey,
@@ -91,5 +92,6 @@ export const QtspCreateSignatureToApiModel: E.Encoder<
         QtspDocumentToSignToApiModel.encode
       ),
     },
+    signature_input: signatureInput,
   }),
 };

--- a/apps/io-func-sign-user/src/infra/namirial/signature-request.ts
+++ b/apps/io-func-sign-user/src/infra/namirial/signature-request.ts
@@ -57,6 +57,7 @@ export const CreateSignatureRequestBody = t.type({
   nonce: NonEmptyString,
   tos_signature: t.string,
   signatures: Signature,
+  signature_input: NonEmptyString,
 });
 
 export type CreateSignatureRequestBody = t.TypeOf<

--- a/apps/io-func-sign-user/src/qtsp.ts
+++ b/apps/io-func-sign-user/src/qtsp.ts
@@ -64,6 +64,7 @@ export const QtspCreateSignaturePayload = t.type({
   tosSignature: t.string,
   signature: t.string,
   documentsToSign: t.array(QtspDocumentToSign),
+  signatureInput: NonEmptyString,
 });
 export type QtspCreateSignaturePayload = t.TypeOf<
   typeof QtspCreateSignaturePayload

--- a/yarn.lock
+++ b/yarn.lock
@@ -2298,6 +2298,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node-jose@npm:^1.1.10":
+  version: 1.1.10
+  resolution: "@types/node-jose@npm:1.1.10"
+  dependencies:
+    "@types/node": "*"
+  checksum: a6cfb9fa1c9a748ef3edd461f93f944f853d8e1cde3b8e860662830ae50aa4adc98015754c12dbd41a1e0d1950ac8be6e2e4daaac0cdea59ea084164a382937c
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:*":
   version: 18.11.10
   resolution: "@types/node@npm:18.11.10"
@@ -6480,6 +6489,7 @@ __metadata:
     "@rushstack/eslint-patch": ^1.2.0
     "@types/crypto-js": ^4.1.1
     "@types/jsrsasign": ^10.5.4
+    "@types/node-jose": ^1.1.10
     azure-functions-core-tools: ^4.0.4895
     crypto-js: ^4.1.1
     date-fns: ^2.29.3
@@ -6488,6 +6498,7 @@ __metadata:
     io-ts: ^2.2.19
     io-ts-types: ^0.5.19
     jest: ^29.3.1
+    jose: ^4.13.1
     jsrsasign: ^10.6.1
     monocle-ts: ^2.3.13
     newtype-ts: ^0.3.5
@@ -7511,6 +7522,13 @@ __metadata:
   bin:
     jest: bin/jest.js
   checksum: 613f4ec657b14dd84c0056b2fef1468502927fd551bef0b19d4a91576a609678fb316c6a5b5fc6120dd30dd4ff4569070ffef3cb507db9bb0260b28ddaa18d7a
+  languageName: node
+  linkType: hard
+
+"jose@npm:^4.13.1":
+  version: 4.13.1
+  resolution: "jose@npm:4.13.1"
+  checksum: 89be959573beee69bd443493887d78799fd42340b45afa2c6681beda30314bcdfa5575f6977203c199e4c3e0ec2fc18d3c94745e7f0d59db51dedfae0efee63d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR modifies the mock signature sent to the QTSP as expected by Lollipop 🍭

#### List of Changes
- Added `signatureInput` parameter to QTSP API
- Added public key to `JWK` changeover
- Added calculation of signatureParams and related signatures
- Added `inResponseTo` field inside SAML with public key hash

#### Motivation and Context
This mock allows us to test the integration with the QTSP even without the presence of the signatures affixed by the app!

#### How Has This Been Tested?
tested locally with cloud resources and QTSP UAT environment

#### Checklist:
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
