### PR TITLE
feat(issuer): [SFEQS-1505] Add CreateIssuerByVatNumberView function

### DIFF
--- a/.changeset/gorgeous-tigers-refuse.md
+++ b/.changeset/gorgeous-tigers-refuse.md
@@ -1,0 +1,5 @@
+---
+"io-func-sign-issuer": minor
+---
+
+Add CreateIssuerByVatNumberView function, triggered by cosmos db to create a lookup table to obtain issuers by their vatNumber

--- a/.changeset/great-moons-perform.md
+++ b/.changeset/great-moons-perform.md
@@ -1,0 +1,5 @@
+---
+"@io-sign/io-sign": minor
+---
+
+Add vatNumber field to issuer

--- a/apps/io-func-sign-issuer/CreateIssuerByVatNumberView/function.json
+++ b/apps/io-func-sign-issuer/CreateIssuerByVatNumberView/function.json
@@ -1,0 +1,26 @@
+{
+  "bindings": [
+    {
+      "type": "cosmosDBTrigger",
+      "name": "documents",
+      "direction": "in",
+      "leaseCollectionName": "issuers-leases",
+      "connectionStringSetting": "CosmosDbConnectionString",
+      "databaseName": "%CosmosDbDatabaseName%",
+      "collectionName": "issuers",
+      "createLeaseCollectionIfNotExists": true,
+      "startFromBeginning": true
+    },
+    {
+      "type": "cosmosDB",
+      "direction": "out",
+      "connectionStringSetting": "CosmosDbConnectionString",
+      "databaseName": "%CosmosDbDatabaseName%",
+      "collectionName": "issuers-by-vat-number",
+      "createIfNotExists": false,
+      "name": "$return"
+    }
+  ],
+  "scriptFile": "../dist/main.js",
+  "entryPoint": "CreateIssuerByVatNumberView"
+}

--- a/apps/io-func-sign-issuer/CreateIssuerByVatNumberView/function.json
+++ b/apps/io-func-sign-issuer/CreateIssuerByVatNumberView/function.json
@@ -2,7 +2,7 @@
   "bindings": [
     {
       "type": "cosmosDBTrigger",
-      "name": "documents",
+      "name": "items",
       "direction": "in",
       "leaseCollectionName": "issuers-leases",
       "connectionStringSetting": "CosmosDbConnectionString",

--- a/apps/io-func-sign-issuer/src/__test__/signature-request-notification.spec.ts
+++ b/apps/io-func-sign-issuer/src/__test__/signature-request-notification.spec.ts
@@ -37,6 +37,7 @@ const issuer: Issuer = {
   email: "info@enpacl-pec.it" as EmailString,
   description: "descrizione dell'ente" as NonEmptyString,
   environment: "TEST",
+  vatNumber: "15376271001" as NonEmptyString,
 };
 
 const dossier = newDossier(issuer, "My dossier", [

--- a/apps/io-func-sign-issuer/src/__test__/signature-request.spec.ts
+++ b/apps/io-func-sign-issuer/src/__test__/signature-request.spec.ts
@@ -17,6 +17,7 @@ const issuer: Issuer = {
   email: "info@enpacl-pec.it" as EmailString,
   description: "descrizione dell'ente" as NonEmptyString,
   environment: "TEST",
+  vatNumber: "15376271001" as NonEmptyString,
 };
 
 const dossier = newDossier(issuer, "My dossier", [

--- a/apps/io-func-sign-issuer/src/__test__/upload.spec.ts
+++ b/apps/io-func-sign-issuer/src/__test__/upload.spec.ts
@@ -26,6 +26,7 @@ describe("UploadMetadata", () => {
       email: "info@enpacl-pec.it" as EmailString,
       description: "descrizione dell'ente" as NonEmptyString,
       environment: "TEST",
+      vatNumber: "15376271001" as NonEmptyString,
     };
 
     const dossier = newDossier(issuer, "My dossier", [

--- a/apps/io-func-sign-issuer/src/app/main.ts
+++ b/apps/io-func-sign-issuer/src/app/main.ts
@@ -23,6 +23,8 @@ import { makeRequestAsWaitForSignatureFunction } from "../infra/azure/functions/
 import { makeRequestAsRejectedFunction } from "../infra/azure/functions/mark-as-rejected";
 import { makeRequestAsSignedFunction } from "../infra/azure/functions/mark-as-signed";
 
+export { run as CreateIssuerByVatNumberView } from "../infra/azure/functions/create-issuers-by-vat-number-view";
+
 import { getConfigFromEnvironment } from "./config";
 
 const configOrError = pipe(

--- a/apps/io-func-sign-issuer/src/infra/azure/cosmos/issuer.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/cosmos/issuer.ts
@@ -27,8 +27,8 @@ import { GetIssuerById, GetIssuerBySubscriptionId } from "../../../issuer";
 const NewIssuer = t.intersection([Issuer, BaseModel]);
 type NewIssuer = t.TypeOf<typeof NewIssuer>;
 
-const RetrievedIssuer = t.intersection([Issuer, CosmosResource]);
-type RetrievedIssuer = t.TypeOf<typeof RetrievedIssuer>;
+export const RetrievedIssuer = t.intersection([Issuer, CosmosResource]);
+export type RetrievedIssuer = t.TypeOf<typeof RetrievedIssuer>;
 
 const partitionKey = "subscriptionId" as const;
 

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/create-issuers-by-vat-number-view.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/create-issuers-by-vat-number-view.ts
@@ -10,9 +10,9 @@ import { validate } from "@io-sign/io-sign/validation";
 import * as t from "io-ts";
 import { RetrievedIssuer } from "../cosmos/issuer";
 
-export const run: AzureFunction = (_, documents: unknown) =>
+export const run: AzureFunction = (_, items: unknown) =>
   pipe(
-    documents,
+    items,
     validate(t.array(RetrievedIssuer)),
     E.map(
       A.map((issuer) => ({

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/create-issuers-by-vat-number-view.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/create-issuers-by-vat-number-view.ts
@@ -1,7 +1,5 @@
 import { AzureFunction } from "@azure/functions";
 
-import { RetrievedIssuer } from "../cosmos/issuer";
-
 import { pipe } from "fp-ts/function";
 import * as E from "fp-ts/Either";
 import * as A from "fp-ts/Array";
@@ -10,6 +8,7 @@ import * as TE from "fp-ts/TaskEither";
 import { validate } from "@io-sign/io-sign/validation";
 
 import * as t from "io-ts";
+import { RetrievedIssuer } from "../cosmos/issuer";
 
 export const run: AzureFunction = (_, documents: unknown) =>
   pipe(

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/create-issuers-by-vat-number-view.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/create-issuers-by-vat-number-view.ts
@@ -1,0 +1,27 @@
+import { AzureFunction } from "@azure/functions";
+
+import { RetrievedIssuer } from "../cosmos/issuer";
+
+import { pipe } from "fp-ts/function";
+import * as E from "fp-ts/Either";
+import * as A from "fp-ts/Array";
+import * as TE from "fp-ts/TaskEither";
+
+import { validate } from "@io-sign/io-sign/validation";
+
+import * as t from "io-ts";
+
+export const run: AzureFunction = (_, documents: unknown) =>
+  pipe(
+    documents,
+    validate(t.array(RetrievedIssuer)),
+    E.map(
+      A.map((issuer) => ({
+        id: issuer.vatNumber,
+        issuerId: issuer.id,
+        subscriptionId: issuer.subscriptionId,
+      }))
+    ),
+    TE.fromEither,
+    TE.toUnion
+  )();

--- a/packages/io-sign/src/issuer.ts
+++ b/packages/io-sign/src/issuer.ts
@@ -17,6 +17,7 @@ export const Issuer = t.type({
   description: NonEmptyString,
   // The need is to know if an issuer is in the experimental phase or not
   environment: IssuerEnvironment,
+  vatNumber: NonEmptyString,
 });
 
 export type Issuer = t.TypeOf<typeof Issuer>;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. Add a new function, triggered by cosmos db, called `CreateIssuerByVatNumberView`
2. Add `vatNumber` property on `Issuer` entity

<!--- Describe your changes in detail -->

#### Motivation and Context

This function creates a "lookup" collection on CosmosDB that allows us to get issuers by their vat number instead of `(issuer.id, subscription.id)`

<!--- Why is this change required? What problem does it solve? -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
