### PR TITLE
fix: [SFEQS-1529] Use `vatNumber` instead of `taxCode`

### DIFF
--- a/apps/io-func-sign-issuer/src/infra/self-care/contract.ts
+++ b/apps/io-func-sign-issuer/src/infra/self-care/contract.ts
@@ -17,6 +17,7 @@ const Institution = t.type({
   description: NonEmptyString,
   digitalAddress: EmailString,
   taxCode: NonEmptyString,
+  vatNumber: NonEmptyString,
 });
 
 const BaseContract = t.type({

--- a/apps/io-func-sign-issuer/src/infra/self-care/encoder.ts
+++ b/apps/io-func-sign-issuer/src/infra/self-care/encoder.ts
@@ -24,6 +24,7 @@ export const ioSignContractToIssuer: E.Encoder<
     description: institution.description,
     // Initially all newly created issuer will be in a test phase.
     environment: "TEST",
-    vatNumber: institution.taxCode,
+    vatNumber: institution.vatNumber,
+    taxCode: institution.taxCode,
   }),
 };


### PR DESCRIPTION
This PR fixes a bug related to issuer creation via self-care that used the `taxCode` instead of the `vatNumber`