### PR TITLE
fix: [SFEQS-1580] Remove filledDocument if exist before creating it

### DIFF
--- a/packages/io-sign/src/infra/azure/storage/blob.ts
+++ b/packages/io-sign/src/infra/azure/storage/blob.ts
@@ -73,3 +73,20 @@ export const downloadContentFromBlob = pipe(
     )
   )
 );
+
+export const deleteBlobIfExist = pipe(
+  RTE.ask<BlobClient>(),
+  RTE.chainTaskEitherK((blobClient) =>
+    pipe(
+      TE.tryCatch(
+        () => blobClient.deleteIfExists(),
+        () => new Error("Unable to delete the blob.")
+      ),
+      TE.filterOrElse(
+        (response) => response.succeeded === true,
+        () => new Error("The specified blob does not exists.")
+      ),
+      TE.map(() => blobClient)
+    )
+  )
+);


### PR DESCRIPTION
When createFilledDocument is called, if a previous filledDocument already exists, it is deleted.

#### List of Changes
- Added `deleteBlobIfExist` in io-sign package
- Added deletion of previous `filledDocument` in `createFilledDocument`

#### Motivation and Context
The presence of a previous document caused a bug when switching spid sessions where the attributes were different.

#### How Has This Been Tested?
Locally

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
