### PR TITLE
feat: [SFEQS-1620] Add document validation analytics event 

### DIFF
--- a/.changeset/funny-crews-cross.md
+++ b/.changeset/funny-crews-cross.md
@@ -1,0 +1,5 @@
+---
+"io-func-sign-issuer": patch
+---
+
+Added document validation analytics events

--- a/apps/io-func-sign-issuer/src/app/main.ts
+++ b/apps/io-func-sign-issuer/src/app/main.ts
@@ -59,7 +59,7 @@ const eventHubBillingClient = new EventHubProducerClient(
   "billing"
 );
 
-const eventHubAnalyticsClient = new EventHubProducerClient(
+const eventAnalyticsClient = new EventHubProducerClient(
   config.azure.eventHubs.analyticsConnectionString,
   "analytics"
 );
@@ -105,7 +105,7 @@ export const Info = makeInfoFunction(
   ioApiClient,
   database,
   eventHubBillingClient,
-  eventHubAnalyticsClient,
+  eventAnalyticsClient,
   eventHubSelfCareContractsConsumer,
   uploadedContainerClient,
   validatedContainerClient,
@@ -114,7 +114,7 @@ export const Info = makeInfoFunction(
 
 export const CreateSignatureRequest = makeCreateSignatureRequestFunction(
   database,
-  eventHubAnalyticsClient
+  eventAnalyticsClient
 );
 
 export const GetSignatureRequest = makeGetSignatureRequestFunction(
@@ -124,7 +124,7 @@ export const GetSignatureRequest = makeGetSignatureRequestFunction(
 export const SetSignatureRequestStatus = makeSetSignatureRequestStatusFunction(
   database,
   onSignatureRequestReadyQueueClient,
-  eventHubAnalyticsClient
+  eventAnalyticsClient
 );
 export const MarkAsWaitForSignature =
   makeRequestAsWaitForSignatureFunction(database);
@@ -133,7 +133,7 @@ export const MarkAsRejected = makeRequestAsRejectedFunction(
   database,
   pdvTokenizerClientWithApiKey,
   ioApiClient,
-  eventHubAnalyticsClient
+  eventAnalyticsClient
 );
 
 export const MarkAsSigned = makeRequestAsSignedFunction(
@@ -141,7 +141,7 @@ export const MarkAsSigned = makeRequestAsSignedFunction(
   pdvTokenizerClientWithApiKey,
   ioApiClient,
   eventHubBillingClient,
-  eventHubAnalyticsClient
+  eventAnalyticsClient
 );
 
 export const GetSignerByFiscalCode = makeGetSignerFunction(
@@ -158,7 +158,7 @@ export const SendNotification = makeSendNotificationFunction(
   database,
   pdvTokenizerClientWithApiKey,
   ioApiClient,
-  eventHubAnalyticsClient
+  eventAnalyticsClient
 );
 
 export const CreateIssuer = makeCreateIssuerFunction(
@@ -202,4 +202,5 @@ export const ValidateUpload = ValidateUploadFunction({
   uploadedFileStorage,
   validatedFileStorage,
   inputDecoder: t.type({ uri: t.string }),
+  eventAnalyticsClient,
 });

--- a/apps/io-func-sign-issuer/src/app/use-cases/validate-upload.ts
+++ b/apps/io-func-sign-issuer/src/app/use-cases/validate-upload.ts
@@ -9,6 +9,7 @@ import * as A from "fp-ts/lib/Array";
 import * as L from "@pagopa/logger";
 
 import { PdfDocumentMetadata } from "@io-sign/io-sign/document";
+import { EventName, createAndSendAnalyticsEvent } from "@io-sign/io-sign/event";
 
 import {
   SignatureFieldAttributes,
@@ -189,6 +190,11 @@ export const validateUpload = flow(
                 RTE.map((meta) => meta.id),
                 RTE.chainW(removeDocumentFromStorage)
               )
+            ),
+            RTE.chainFirstW(() =>
+              createAndSendAnalyticsEvent(signatureRequest)(
+                EventName.DOCUMENT_UPLOADED
+              )
             )
           )
         ),
@@ -207,7 +213,12 @@ export const validateUpload = flow(
               })
             ),
             // Remove REJECTED file from temp storage
-            RTE.chainW(() => removeDocumentFromStorage(meta.id))
+            RTE.chainW(() => removeDocumentFromStorage(meta.id)),
+            RTE.chainFirstW(() =>
+              createAndSendAnalyticsEvent(signatureRequest)(
+                EventName.DOCUMENT_REJECTED
+              )
+            )
           )
         )
       )

--- a/packages/io-sign/src/event.ts
+++ b/packages/io-sign/src/event.ts
@@ -1,6 +1,11 @@
 import { IsoDateFromString } from "@pagopa/ts-commons/lib/dates";
 import * as t from "io-ts";
 import * as TE from "fp-ts/lib/TaskEither";
+import * as E from "fp-ts/lib/Either";
+import * as RTE from "fp-ts/lib/ReaderTaskEither";
+import * as L from "@pagopa/logger";
+
+import { pipe } from "fp-ts/lib/function";
 import { Id, newId } from "./id";
 import {
   SignatureRequestDraft,
@@ -12,6 +17,7 @@ import {
   SignatureRequestWaitForQtsp,
 } from "./signature-request";
 import { IssuerEnvironment } from "./issuer";
+import { ConsoleLogger } from "./infra/console-logger";
 
 const EventId = Id;
 
@@ -53,6 +59,14 @@ const BaseEvent = t.type({
 
 type BaseEvent = t.TypeOf<typeof BaseEvent>;
 
+type SignatureRequest =
+  | SignatureRequestDraft
+  | SignatureRequestSigned
+  | SignatureRequestReady
+  | SignatureRequestToBeSigned
+  | SignatureRequestWaitForQtsp
+  | SignatureRequestRejected;
+
 export const BillingEvent = t.intersection([
   BaseEvent,
   t.type({ name: t.literal(EventName.SIGNATURE_SIGNED) }),
@@ -90,15 +104,7 @@ export type AnalyticsEvent = t.TypeOf<typeof AnalyticsEvent>;
 
 export const createAnalyticsEvent =
   (eventName: EventName) =>
-  (
-    signatureRequest:
-      | SignatureRequestDraft
-      | SignatureRequestSigned
-      | SignatureRequestReady
-      | SignatureRequestToBeSigned
-      | SignatureRequestWaitForQtsp
-      | SignatureRequestRejected
-  ): AnalyticsEvent => ({
+  (signatureRequest: SignatureRequest): AnalyticsEvent => ({
     id: newId(),
     name: eventName,
     signatureRequestId: signatureRequest.id,
@@ -120,11 +126,78 @@ export type SendEvent = (
 export type CreateAndSendAnalyticsEvent = (
   eventName: EventName
 ) => (
-  signatureRequest:
-    | SignatureRequestDraft
-    | SignatureRequestSigned
-    | SignatureRequestReady
-    | SignatureRequestToBeSigned
-    | SignatureRequestWaitForQtsp
-    | SignatureRequestRejected
+  signatureRequest: SignatureRequest
 ) => TE.TaskEither<Error, typeof signatureRequest>;
+
+type EventData = {
+  body: GenericEvent;
+};
+
+type EventDataBatch = {
+  tryAdd(eventData: EventData): boolean;
+};
+
+type EventProducerClient = {
+  createBatch(): Promise<EventDataBatch>;
+  close: () => Promise<void>;
+  sendBatch(batch: EventDataBatch): Promise<void>;
+};
+
+type EventAnalyticsClient = {
+  eventAnalyticsClient: EventProducerClient;
+};
+
+export const sendEvent =
+  (client: EventProducerClient) =>
+  (event: GenericEvent): TE.TaskEither<Error, GenericEvent> =>
+    pipe(
+      TE.tryCatch(() => client.createBatch(), E.toError),
+      TE.chain((eventDataBatch) =>
+        eventDataBatch.tryAdd({ body: event })
+          ? TE.right(eventDataBatch)
+          : TE.left(new Error("Unable to add new events to event batch!"))
+      ),
+      TE.chain((eventDataBatch) =>
+        TE.tryCatch(() => client.sendBatch(eventDataBatch), E.toError)
+      ),
+      TE.map(() => event)
+    );
+
+export const createAndSendAnalyticsEvent =
+  (signatureRequest: SignatureRequest) =>
+  (
+    eventName: EventName
+  ): RTE.ReaderTaskEither<
+    EventAnalyticsClient,
+    Error,
+    typeof signatureRequest
+  > =>
+  ({ eventAnalyticsClient }) =>
+    pipe(
+      signatureRequest,
+      createAnalyticsEvent(eventName),
+      sendEvent(eventAnalyticsClient),
+      TE.map(() => signatureRequest),
+      TE.chainFirstIOK(() =>
+        L.debug("Send analytics event", {
+          eventName,
+          signatureRequest,
+        })({
+          logger: ConsoleLogger,
+        })
+      ),
+      // This is a fire and forget operation
+      TE.altW(() =>
+        pipe(
+          TE.right(signatureRequest),
+          TE.chainFirstIOK(() =>
+            L.error("Unable to send analytics event", {
+              eventName,
+              signatureRequest,
+            })({
+              logger: ConsoleLogger,
+            })
+          )
+        )
+      )
+    );

--- a/packages/io-sign/src/infra/azure/event-hubs/event.ts
+++ b/packages/io-sign/src/infra/azure/event-hubs/event.ts
@@ -1,16 +1,14 @@
 import { pipe } from "fp-ts/lib/function";
 
 import * as TE from "fp-ts/lib/TaskEither";
-import * as E from "fp-ts/lib/Either";
 import { EventHubProducerClient } from "@azure/event-hubs";
-import * as L from "@pagopa/logger";
-import { ConsoleLogger } from "../../console-logger";
 
 import {
-  createAnalyticsEvent,
+  createAndSendAnalyticsEvent,
   CreateAndSendAnalyticsEvent,
   EventName,
   GenericEvent,
+  sendEvent,
   SendEvent,
 } from "../../../event";
 import {
@@ -25,21 +23,10 @@ import {
 export const makeSendEvent =
   (client: EventHubProducerClient): SendEvent =>
   (event: GenericEvent) =>
-    pipe(
-      TE.tryCatch(() => client.createBatch(), E.toError),
-      TE.chain((eventDataBatch) =>
-        eventDataBatch.tryAdd({ body: event })
-          ? TE.right(eventDataBatch)
-          : TE.left(new Error("Unable to add new events to event hub batch!"))
-      ),
-      TE.chain((eventDataBatch) =>
-        TE.tryCatch(() => client.sendBatch(eventDataBatch), E.toError)
-      ),
-      TE.map(() => event)
-    );
+    pipe(event, sendEvent(client));
 
 export const makeCreateAndSendAnalyticsEvent =
-  (client: EventHubProducerClient): CreateAndSendAnalyticsEvent =>
+  (eventAnalyticsClient: EventHubProducerClient): CreateAndSendAnalyticsEvent =>
   (eventName: EventName) =>
   (
     signatureRequest:
@@ -51,30 +38,6 @@ export const makeCreateAndSendAnalyticsEvent =
       | SignatureRequestRejected
   ): TE.TaskEither<Error, typeof signatureRequest> =>
     pipe(
-      signatureRequest,
-      createAnalyticsEvent(eventName),
-      makeSendEvent(client),
-      TE.map(() => signatureRequest),
-      TE.chainFirstIOK(() =>
-        L.debug("Send analytics event", {
-          eventName,
-          signatureRequest,
-        })({
-          logger: ConsoleLogger,
-        })
-      ),
-      // This is a fire and forget operation
-      TE.altW(() =>
-        pipe(
-          TE.right(signatureRequest),
-          TE.chainFirstIOK(() =>
-            L.error("Unable to send analytics event", {
-              eventName,
-              signatureRequest,
-            })({
-              logger: ConsoleLogger,
-            })
-          )
-        )
-      )
+      { eventAnalyticsClient },
+      pipe(eventName, createAndSendAnalyticsEvent(signatureRequest))
     );


### PR DESCRIPTION
Add analytics events for accepted or rejected document. It also implements the `createAndSendAnalyticsEvent` as an RTE to support the new handler-kit.

#### List of Changes
- Added `createAndSendAnalyticsEvent` as RTE
- Added DOCUMENT_UPLOADED and DOCUMENT_REJECTED analytics events
- Converted the old `makeCreateAndSendAnalyticsEvent` to use the RTE


#### How Has This Been Tested?
Tested locally

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
