### PR TITLE
chore: Code refactor and patch document validation on issuer SDK

### DIFF
--- a/packages/io-sign-issuer-sdk/package.json
+++ b/packages/io-sign-issuer-sdk/package.json
@@ -23,7 +23,7 @@
     "generate:api-client": "npx @openapitools/openapi-generator-cli generate -i ./../../apps/io-func-sign-issuer/openapi.yaml -g typescript-fetch -o ../io-sign-api-client --additional-properties=npmName=@io-sign/io-sign-api-client"
   },
   "dependencies": {
-    "@io-sign/io-sign-api-client": "^1.0.0",
+    "@io-sign/io-sign-api-client": "workspace:^",
     "@pagopa/io-functions-commons": "^26.2.1",
     "@pagopa/ts-commons": "^11.0.0",
     "dotenv": "^16.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1334,7 +1334,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@io-sign/io-sign-api-client@^1.0.0, @io-sign/io-sign-api-client@workspace:packages/io-sign-api-client":
+"@io-sign/io-sign-api-client@workspace:^, @io-sign/io-sign-api-client@workspace:packages/io-sign-api-client":
   version: 0.0.0-use.local
   resolution: "@io-sign/io-sign-api-client@workspace:packages/io-sign-api-client"
   dependencies:
@@ -1346,7 +1346,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@io-sign/io-sign-issuer-sdk@workspace:packages/io-sign-issuer-sdk"
   dependencies:
-    "@io-sign/io-sign-api-client": ^1.0.0
+    "@io-sign/io-sign-api-client": "workspace:^"
     "@jest/globals": ^29.3.1
     "@pagopa/eslint-config": ^3.0.0
     "@pagopa/io-functions-commons": ^26.2.1


### PR DESCRIPTION
This PR applies some fixes to the SDK that is being developed by @filippo-tenaglia 
In particular:
- Adds better error handling
- Adds a patch on document upload and validation

Thanks to this SDK a very important BUG of `io-sign` has come out. In particular, it is not possible to upload all the files together (although they have different urls and the API allow it) and then validate them as there is no lock on the DB resources. What you have to do is wait for each single document to be validated before moving on to the next document.

I will do a more detailed description of this bug on confluence.

