### PR TITLE
fix: [SFEQS-1660] Add `patchDocument` to signature request db model

### DIFF
--- a/.changeset/violet-mangos-jog.md
+++ b/.changeset/violet-mangos-jog.md
@@ -1,0 +1,5 @@
+---
+"io-func-sign-issuer": minor
+---
+
+Fixed the bug that didn't allow documents to be uploaded at the same time

--- a/apps/io-func-sign-issuer/src/app/use-cases/validate-upload.ts
+++ b/apps/io-func-sign-issuer/src/app/use-cases/validate-upload.ts
@@ -32,10 +32,10 @@ import {
 
 import {
   getSignatureRequest,
-  upsertSignatureRequest,
   markDocumentAsReady,
   markDocumentAsRejected,
   startValidationOnDocument,
+  patchSignatureRequestDocument,
 } from "../../signature-request";
 
 export const validateExistingSignatureField =
@@ -173,7 +173,7 @@ export const validateUpload = flow(
                 markDocumentAsReady(meta.documentId, url, documentMetadata)
               )
             ),
-            RTE.chainW(upsertSignatureRequest),
+            RTE.chainW(patchSignatureRequestDocument(meta.documentId)),
             // Update upload metadata and remove document
             // fromt temp storage
             RTE.chainW(() =>
@@ -204,8 +204,7 @@ export const validateUpload = flow(
             signatureRequest,
             markDocumentAsRejected(meta.documentId, e.message),
             RTE.fromEither,
-            RTE.chain(upsertSignatureRequest),
-
+            RTE.chainW(patchSignatureRequestDocument(meta.documentId)),
             RTE.chainFirstW(() =>
               L.infoRTE("validation done", {
                 isDocumentValid: false,

--- a/apps/io-func-sign-issuer/src/infra/azure/cosmos/signature-request.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/cosmos/signature-request.ts
@@ -117,7 +117,7 @@ export class CosmosDbSignatureRequestRepository
       TE.fromEither,
       TE.chain((index) =>
         pipe(
-          /* I can't use the io-functions-commons patch function here as it doesn't support
+          /* Here it is not possible to use the io-functions-commons patch function as it doesn't support
            * updating a single item inside an array (documents)
            */
           TE.tryCatch(

--- a/apps/io-func-sign-issuer/src/infra/azure/cosmos/signature-request.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/cosmos/signature-request.ts
@@ -12,7 +12,6 @@ import * as t from "io-ts";
 import * as E from "fp-ts/lib/Either";
 import * as TE from "fp-ts/lib/TaskEither";
 import * as A from "fp-ts/lib/Array";
-import * as O from "fp-ts/lib/Option";
 import * as cosmos from "@azure/cosmos";
 import { pipe, flow } from "fp-ts/lib/function";
 import { toCosmosDatabaseError } from "@io-sign/io-sign/infra/azure/cosmos/errors";
@@ -134,8 +133,7 @@ export class CosmosDbSignatureRequestRepository
           TE.chainW((patchResponse) =>
             pipe(
               patchResponse.resource,
-              O.fromNullable,
-              TE.fromOption(() =>
+              TE.fromNullable(
                 CosmosErrorResponse({
                   code: 404,
                   message: "item not found for input id",

--- a/apps/io-func-sign-issuer/src/infra/http/handlers/__test__/create-signature-request.spec.ts
+++ b/apps/io-func-sign-issuer/src/infra/http/handlers/__test__/create-signature-request.spec.ts
@@ -96,6 +96,8 @@ describe("CreateSignatureRequestHandler", () => {
       upsert: () => TE.left(new Error("not implemented")),
       findByDossier: () => Promise.reject("not implemented"),
       insert: (request) => TE.right(request),
+      patchDocument: (request, documentId) =>
+        TE.left(new Error("not implemented")),
     };
   });
 
@@ -200,6 +202,8 @@ describe("CreateSignatureRequestHandler", () => {
         upsert: () => TE.left(new Error("not implemented")),
         findByDossier: () => Promise.reject("not implemented"),
         insert: () => TE.left(new Error("insert failed")),
+        patchDocument: (request, documentId) =>
+          TE.left(new Error("not implemented")),
       };
     const req: H.HttpRequest = {
       ...H.request("https://api.test.it/"),

--- a/apps/io-func-sign-issuer/src/infra/http/handlers/__test__/get-requests-by-dossier.spec.ts
+++ b/apps/io-func-sign-issuer/src/infra/http/handlers/__test__/get-requests-by-dossier.spec.ts
@@ -97,6 +97,8 @@ describe("GetRequestsByDossierHandler", () => {
       get: () => TE.left(new Error("not implemented")),
       upsert: () => TE.left(new Error("not implemented")),
       insert: () => TE.left(new Error("not implemented")),
+      patchDocument: (request, documentId) =>
+        TE.left(new Error("not implemented")),
     };
   });
 

--- a/apps/io-func-sign-issuer/src/infra/http/handlers/__test__/get-signature-request.spec.ts
+++ b/apps/io-func-sign-issuer/src/infra/http/handlers/__test__/get-signature-request.spec.ts
@@ -70,6 +70,8 @@ describe("GetSignatureRequestHandler", () => {
       upsert: () => TE.left(new Error("not implemented")),
       findByDossier: () => Promise.reject("not implemented"),
       insert: () => TE.left(new Error("not implemented")),
+      patchDocument: (request, documentId) =>
+        TE.left(new Error("not implemented")),
     };
   });
 

--- a/apps/io-func-sign-issuer/src/signature-request.ts
+++ b/apps/io-func-sign-issuer/src/signature-request.ts
@@ -402,6 +402,10 @@ export type SignatureRequestRepository = {
     issuerId: SignatureRequest["issuerId"]
   ) => TE.TaskEither<Error, O.Option<SignatureRequest>>;
   upsert: (request: SignatureRequest) => TE.TaskEither<Error, SignatureRequest>;
+  patchDocument: (
+    request: SignatureRequest,
+    documentId: Document["id"]
+  ) => TE.TaskEither<Error, SignatureRequest>;
   findByDossier: (
     dossier: Dossier,
     options?: { maxItemCount?: number; continuationToken?: string }
@@ -456,6 +460,18 @@ export const upsertSignatureRequest =
   > =>
   ({ signatureRequestRepository: repo }) =>
     repo.upsert(request);
+
+export const patchSignatureRequestDocument =
+  (documentId: Document["id"]) =>
+  (
+    request: SignatureRequest
+  ): RTE.ReaderTaskEither<
+    SignatureRequestEnvironment,
+    Error,
+    SignatureRequest
+  > =>
+  ({ signatureRequestRepository: repo }) =>
+    pipe(repo.patchDocument(request, documentId));
 
 export const findSignatureRequestsByDossier =
   (


### PR DESCRIPTION
Fixes a bug that didn't allow documents to be uploaded at the same time due to a concurrency issue. 

#### List of Changes
- Added the function for patching a single document on the signatureRequest object present on cosmosDb

#### Motivation and Context
More detail [here](https://pagopa.atlassian.net/wiki/spaces/SFEQS/pages/713162998/IO-SIGN-RFC-BUG-0001+Bug+sul+processo+di+validazione+dei+documenti)

#### How Has This Been Tested?
Tested locally

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
