### PR TITLE
fix(issuer): Make signature fields optional in validate-document

### DIFF
--- a/.changeset/silver-wolves-unite.md
+++ b/.changeset/silver-wolves-unite.md
@@ -1,0 +1,5 @@
+---
+"io-func-sign-issuer": patch
+---
+
+(validate-document) make signature fields optional, defaults to empty array

--- a/apps/io-func-sign-issuer/openapi.yaml
+++ b/apps/io-func-sign-issuer/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Firma con IO - Issuer API
-  version: 1.2.0
+  version: 1.2.1
 servers:
   - url: https://api.io.pagopa.it/api/v1/sign
     description: production
@@ -326,6 +326,8 @@ paths:
                   type: array
                   items:
                     $ref: "#/components/schemas/SignatureField"
+              required:
+                - document
             encoding:
               document:
                 contentType: application/pdf

--- a/apps/io-func-sign-issuer/src/infra/http/decoders/__test__/document-validation.spec.ts
+++ b/apps/io-func-sign-issuer/src/infra/http/decoders/__test__/document-validation.spec.ts
@@ -43,7 +43,6 @@ describe("requireFilesForValidation", () => {
         "hello.txt",
         Buffer.from("hello from a wrong file!"),
       ]),
-      multipartRequest(["application/pdf", "document.pdf", samplePdf]),
       multipartRequest(
         ["application/pdf", "document.pdf", samplePdf],
         ["application/json", "fields.json", Buffer.from(JSON.stringify({}))]
@@ -90,6 +89,7 @@ describe("requireFilesForValidation", () => {
     const requests = [
       multipartRequest(validPdfFile, validSignatureFields),
       multipartRequest(validSignatureFields, validPdfFile),
+      multipartRequest(validPdfFile),
     ];
     const results = await Promise.all(
       requests.map((req) => requireFilesForValidation(req)())


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. the `validate document` endpoint now it also accept only the pdf document to validate if there are no signature fields to be tracked

<!--- Describe your changes in detail -->

#### Motivation and Context

the signature fields are optional, even in the rest API this information can be omitted

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

unit test

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
