### PR TITLE
fix (issuer): [SFEQS-1708] Fix document validation on PDF with text fields

### DIFF
--- a/.changeset/eight-terms-visit.md
+++ b/.changeset/eight-terms-visit.md
@@ -1,0 +1,5 @@
+---
+"@io-sign/io-sign": patch
+---
+
+Exclude text fields from PDF metadata

--- a/packages/io-sign/src/infra/pdf.ts
+++ b/packages/io-sign/src/infra/pdf.ts
@@ -38,7 +38,8 @@ export const getPdfMetadata = (
                 .map((field) => ({
                   type: field.constructor.name,
                   name: field.getName(),
-                })),
+                }))
+                .filter((field) => field.type === "PDFSignature"),
             E.toError
           ),
           E.fold(() => [], identity),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. now in `PdfDocumentMetadata` are included only `PDFSignature` fields

<!--- Describe your changes in detail -->

#### Motivation and Context

the issuers was unable to upload PDF documents that contains text fields

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
