### PR TITLE
feat(backoffice): [SFEQS-1885] Implemented authentication from Self Care + minor improvements

### DIFF
--- a/apps/io-sign-backoffice-ca/.env
+++ b/apps/io-sign-backoffice-ca/.env
@@ -1,0 +1,16 @@
+DOCUMENTATION_URL=https://docs.pagopa.it/manuale-operativo-di-firma-con-io/
+
+# SELFCARE
+# -- portal
+SELFCARE_URL=https://selfcare.pagopa.it
+SELFCARE_SUPPORT_URL=https://selfcare.pagopa.it/assistenza
+SELFCARE_LOGOUT_URL=https://selfcare.pagopa.it/auth/logout
+# -- api
+SELFCARE_API_URL=https://api.selfcare.pagopa.it/external/v2
+SELFCARE_API_KEY=# override this variable in .env.local
+
+# AUTH
+AUTH_SELFCARE_JWK_SET_URL=https://selfcare.pagopa.it/.well-known/jwks.json
+AUTH_SELFCARE_JWT_ISSUER=https://selfcare.pagopa.it
+AUTH_SELFCARE_JWT_AUDIENCE=api.io.pagopa.it
+AUTH_SESSION_SECRET=# override this variable in .env.local

--- a/apps/io-sign-backoffice-ca/.env.development
+++ b/apps/io-sign-backoffice-ca/.env.development
@@ -1,0 +1,13 @@
+# SELFCARE
+# -- portal
+SELFCARE_URL=https://uat.selfcare.pagopa.it
+SELFCARE_SUPPORT_URL=https://uat.selfcare.pagopa.it/assistenza
+SELFCARE_LOGOUT_URL=https://uat.selfcare.pagopa.it/auth/logout
+# -- api
+SELFCARE_API_URL=https://uat.api.selfcare.pagopa.it/external/v2
+SELFCARE_API_KEY=# override this variable in .env.development.local
+
+# AUTH
+AUTH_SELFCARE_JWK_SET_URL=https://uat.selfcare.pagopa.it/.well-known/jwks.json
+AUTH_SELFCARE_JWT_ISSUER=https://uat.selfcare.pagopa.it
+AUTH_SELFCARE_JWT_AUDIENCE=firmaconio.selfcare.pagopa.it

--- a/apps/io-sign-backoffice-ca/.gitignore
+++ b/apps/io-sign-backoffice-ca/.gitignore
@@ -25,7 +25,9 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+!.env*
 .env*.local
+
 
 # vercel
 .vercel

--- a/apps/io-sign-backoffice-ca/next.config.js
+++ b/apps/io-sign-backoffice-ca/next.config.js
@@ -1,3 +1,5 @@
+const withNextIntl = require("next-intl/plugin")("./src/i18n.tsx");
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -6,6 +8,7 @@ const nextConfig = {
       transform: "@mui/icons-material/{{member}}",
     },
   },
+  output: "standalone",
 };
 
-module.exports = nextConfig;
+module.exports = withNextIntl(nextConfig);

--- a/apps/io-sign-backoffice-ca/package.json
+++ b/apps/io-sign-backoffice-ca/package.json
@@ -20,11 +20,13 @@
     "@types/react-dom": "18.2.6",
     "eslint": "8.44.0",
     "eslint-config-next": "13.4.8",
-    "next": "13.4.8",
-    "next-intl": "^2.17.5",
+    "jose": "^4.14.4",
+    "next": "^13.4.11",
+    "next-intl": "3.0.0-beta.8",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "5.1.6",
+    "vitest": "^0.33.0",
     "zod": "^3.21.4"
   }
 }

--- a/apps/io-sign-backoffice-ca/src/app/[locale]/[institution]/layout.tsx
+++ b/apps/io-sign-backoffice-ca/src/app/[locale]/[institution]/layout.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { Stack } from "@/components/mui";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <Stack flexGrow={1}>{children}</Stack>;
+}

--- a/apps/io-sign-backoffice-ca/src/app/[locale]/[institution]/page.tsx
+++ b/apps/io-sign-backoffice-ca/src/app/[locale]/[institution]/page.tsx
@@ -1,0 +1,32 @@
+import { useTranslations } from "next-intl";
+
+import { Stack, Typography, Button } from "@/components/mui";
+import { IllusPaymentCompleted } from "@pagopa/mui-italia";
+
+export default function Index() {
+  const t = useTranslations("Index");
+  return (
+    <Stack
+      direction="column"
+      alignItems="center"
+      justifyContent="center"
+      flexGrow={1}
+      spacing={3}
+    >
+      <IllusPaymentCompleted />
+      <Stack spacing={2} alignItems="center">
+        <Typography variant="h4">{t("title")}</Typography>
+        <Typography
+          variant="body1"
+          sx={{ whiteSpace: "pre-line" }}
+          align="center"
+        >
+          {t.rich("body")}
+        </Typography>
+      </Stack>
+      <Button variant="outlined" href={process.env.SELFCARE_URL}>
+        {t("cta")}
+      </Button>
+    </Stack>
+  );
+}

--- a/apps/io-sign-backoffice-ca/src/app/[locale]/_components/Footer.tsx
+++ b/apps/io-sign-backoffice-ca/src/app/[locale]/_components/Footer.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { FooterPostLogin, FooterLegal } from "@pagopa/mui-italia";
+
+type Props = {
+  legalContent: React.ReactNode;
+  companyLink: {
+    href: string;
+    ariaLabel: string;
+  };
+};
+
+export default function Footer({ legalContent, companyLink }: Props) {
+  return (
+    <>
+      <FooterPostLogin
+        currentLangCode="it"
+        languages={{ it: { it: "Italiano" } }}
+        onLanguageChanged={() => {}}
+        companyLink={companyLink}
+        links={[]}
+      />
+      <FooterLegal
+        content={<span style={{ whiteSpace: "pre-line" }}>{legalContent}</span>}
+      />
+    </>
+  );
+}

--- a/apps/io-sign-backoffice-ca/src/app/[locale]/_components/HeaderWithAccountInfo.tsx
+++ b/apps/io-sign-backoffice-ca/src/app/[locale]/_components/HeaderWithAccountInfo.tsx
@@ -1,16 +1,39 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { HeaderAccount, RootLinkType } from "@pagopa/mui-italia";
+import { User } from "@/app/auth/_lib/user";
+import { useRouter } from "next/navigation";
 
-import { HeaderAccount } from "@pagopa/mui-italia";
+type Props = {
+  loggedUser: User;
+  documentationUrl: string;
+  supportUrl: string;
+  companyLink: RootLinkType;
+};
 
-export default function HeaderWithAccountInfo() {
-  const t = useTranslations("HeaderWithAccountInfo");
-  const rootLink = {
-    label: "PagoPA S.p.A",
-    href: "https://www.pagopa.it/",
-    title: t("rootLink.title"),
-    ariaLabel: t("rootLink.ariaLabel"),
-  };
-  return <HeaderAccount rootLink={rootLink} onAssistanceClick={() => {}} />;
+export default function HeaderWithAccountInfo({
+  loggedUser,
+  documentationUrl,
+  supportUrl,
+  companyLink,
+}: Props) {
+  const router = useRouter();
+  function handleAssistanceClick() {
+    window.location.href = supportUrl;
+  }
+  function handleDocumentationClick() {
+    window.open(documentationUrl, "_blank", "noreferrer");
+  }
+  function handleLogout() {
+    router.push("/auth/logout");
+  }
+  return (
+    <HeaderAccount
+      rootLink={companyLink}
+      onAssistanceClick={handleAssistanceClick}
+      onDocumentationClick={handleDocumentationClick}
+      loggedUser={loggedUser}
+      onLogout={handleLogout}
+    />
+  );
 }

--- a/apps/io-sign-backoffice-ca/src/app/[locale]/layout.tsx
+++ b/apps/io-sign-backoffice-ca/src/app/[locale]/layout.tsx
@@ -1,38 +1,77 @@
-import { NextIntlClientProvider } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 
 import ThemeRegistry from "@/components/mui/ThemeRegistry";
+import { Stack } from "@/components/mui";
+
 import HeaderWithAccountInfo from "./_components/HeaderWithAccountInfo";
+import Footer from "./_components/Footer";
 
-export function generateStaticParams() {
-  return [{ locale: "it" }];
-}
+import { getLoggedUser, User } from "@/app/auth/_lib/user";
 
-export default async function RootLayoutWithLocaleAndTheme({
+import { getConfig } from "@/config";
+
+export default async function RootLayout({
   children,
-  params: { locale },
+  params,
 }: {
   children: React.ReactNode;
-  params: {
-    locale: string;
-  };
+  params: { locale: string };
 }) {
-  let messages;
-  try {
-    messages = (await import(`../../messages/${locale}.json`)).default;
-  } catch (error) {
+  const config = getConfig();
+  const locale = useLocale();
+  if (params.locale !== locale) {
     notFound();
   }
+  let loggedUser: User;
+  try {
+    loggedUser = await getLoggedUser();
+  } catch (e) {
+    redirect(config.selfCare.portal.url.href);
+  }
+  return (
+    <RootLayoutContent locale={locale} loggedUser={loggedUser}>
+      {children}
+    </RootLayoutContent>
+  );
+}
+
+function RootLayoutContent({
+  loggedUser,
+  locale,
+  children,
+}: {
+  loggedUser: User;
+  locale: string;
+  children: React.ReactNode;
+}) {
+  const config = getConfig();
+  const t = useTranslations();
+  const companyLink = {
+    href: "https://pagopa.it",
+    ariaLabel: t("common.companyLink.ariaLabel"),
+    title: t("common.companyLink.title"),
+    label: "PagoPA S.p.A.",
+  };
   return (
     <html lang={locale}>
       <body>
-        <NextIntlClientProvider locale={locale} messages={messages}>
-          <ThemeRegistry>
-            <HeaderWithAccountInfo />
-            {children}
-          </ThemeRegistry>
-        </NextIntlClientProvider>
+        <ThemeRegistry>
+          <Stack sx={{ minHeight: "100vh" }}>
+            <HeaderWithAccountInfo
+              companyLink={companyLink}
+              loggedUser={loggedUser}
+              documentationUrl={config.documentationUrl.href}
+              supportUrl={config.selfCare.portal.supportUrl.href}
+            />
+            <Stack sx={{ flexGrow: 1 }}>{children}</Stack>
+            <Footer
+              companyLink={companyLink}
+              legalContent={t.rich("Footer.legal")}
+            />
+          </Stack>
+        </ThemeRegistry>
       </body>
     </html>
   );

--- a/apps/io-sign-backoffice-ca/src/app/[locale]/page.tsx
+++ b/apps/io-sign-backoffice-ca/src/app/[locale]/page.tsx
@@ -1,8 +1,0 @@
-"use client";
-
-import { useTranslations } from "next-intl";
-
-export default function Index() {
-  const t = useTranslations("Index");
-  return <h1>{t("title")}</h1>;
-}

--- a/apps/io-sign-backoffice-ca/src/app/auth/[id]/route.ts
+++ b/apps/io-sign-backoffice-ca/src/app/auth/[id]/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest } from "next/server";
+import { redirect } from "next/navigation";
+import { authenticate } from "@/app/auth/_lib/user";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const { institutionId } = await authenticate(params.id);
+  redirect(`/${institutionId}`);
+}

--- a/apps/io-sign-backoffice-ca/src/app/auth/_lib/__test__/self-care.spec.ts
+++ b/apps/io-sign-backoffice-ca/src/app/auth/_lib/__test__/self-care.spec.ts
@@ -1,0 +1,58 @@
+import { describe, vi, it, expect } from "vitest";
+
+import { verifySelfCareIdToken } from "../self-care";
+
+const { jwtVerify, createRemoteJWKSet } = vi.hoisted(() => ({
+  jwtVerify: vi.fn(
+    async (): Promise<{}> => ({
+      payload: {
+        uid: "42f7d28a-ccca-487d-8777-040b07b7e622",
+        name: "Mario",
+        family_name: "Rossi",
+        email: "mario.rossi+test@pagopa.it",
+        organization: {
+          id: "42f7d28a-ccca-487d-8777-040b07b7e622",
+        },
+        iat: Date.now(),
+        desired_exp: Date.now() + 15 * 60 * 1000,
+      },
+    })
+  ),
+  createRemoteJWKSet: vi.fn(() => "test-jwkset"),
+}));
+
+vi.mock("jose", () => ({
+  jwtVerify,
+  createRemoteJWKSet,
+}));
+
+vi.stubEnv(
+  "AUTH_SELFCARE_JWK_SET_URL",
+  "https://selfcare.pagopa.it/.well-known/jwks.json"
+);
+
+vi.stubEnv("AUTH_SELFCARE_JWT_ISSUER", "test-issuer");
+vi.stubEnv("AUTH_SELFCARE_JWT_AUDIENCE", "test-audience");
+
+describe("verifySelfCareIdToken", () => {
+  it("verifies the id token using the right config", async () => {
+    await verifySelfCareIdToken("myidtok");
+    expect(createRemoteJWKSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        href: process.env.AUTH_SELFCARE_JWK_SET_URL,
+      })
+    );
+    expect(jwtVerify).toHaveBeenCalledWith("myidtok", "test-jwkset", {
+      issuer: "test-issuer",
+      audience: "test-audience",
+    });
+  });
+  it("throws an error if the id token does not contain the expected payload", async () => {
+    jwtVerify.mockImplementationOnce(async () => ({
+      payload: {},
+    }));
+    await expect(() =>
+      verifySelfCareIdToken("invalid-id-token")
+    ).rejects.toThrowError();
+  });
+});

--- a/apps/io-sign-backoffice-ca/src/app/auth/_lib/__test__/session.spec.ts
+++ b/apps/io-sign-backoffice-ca/src/app/auth/_lib/__test__/session.spec.ts
@@ -1,0 +1,86 @@
+import { vi, it, expect, describe, beforeEach, afterEach } from "vitest";
+
+import { cookies } from "next/headers";
+
+import {
+  createSessionCookie,
+  destroySessionCookie,
+  getPayloadFromSessionCookie,
+} from "../session";
+
+vi.stubEnv("AUTH_SESSION_SECRET", "_TEST_");
+
+vi.setSystemTime(1689629834);
+
+const { setCookie, getCookie } = vi.hoisted(() => ({
+  setCookie: vi.fn(),
+  getCookie: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(() => ({ set: setCookie, get: getCookie })),
+}));
+
+type TestContext = {
+  payload: {
+    quote: string;
+  };
+};
+
+beforeEach<TestContext>((ctx) => {
+  ctx.payload = {
+    quote: "Quality is not an act, it is a habit.",
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("createSessionCookie", () => {
+  it<TestContext>("creates a session cookie with the given (signed) payload", async (ctx) => {
+    await createSessionCookie(ctx.payload);
+    expect(setCookie.mock.lastCall[1]).toMatchInlineSnapshot(
+      '"eyJhbGciOiJIUzI1NiJ9.eyJxdW90ZSI6IlF1YWxpdHkgaXMgbm90IGFuIGFjdCwgaXQgaXMgYSBoYWJpdC4iLCJpYXQiOjE2ODk2MjksImV4cCI6MTY5MDUyOTgzNH0.Z8iwAN5NJ4R3D-y38RU4sXGhl8UaiMSY6EpU4DOzk0Y"'
+    );
+  });
+});
+
+describe("destroySessionCookie", () => {
+  it("replaces the session cookie value with an empty string", () => {
+    destroySessionCookie();
+    expect(cookies().set).toBeCalledWith(
+      "_iosign_session",
+      "",
+      expect.objectContaining({
+        maxAge: 0,
+      })
+    );
+  });
+});
+
+describe("getPayloadFromSessionCookie", () => {
+  it("throws an exception if the cookie is not found", async () => {
+    await expect(() => getPayloadFromSessionCookie()).rejects.toThrowError(
+      /unable to get the session cookie/
+    );
+  });
+  it<TestContext>("returns the decoded payload", async (ctx) => {
+    await createSessionCookie(ctx.payload);
+    getCookie.mockImplementationOnce(() => ({
+      value: setCookie.mock.lastCall[1],
+    }));
+    await expect(getPayloadFromSessionCookie()).resolves.toEqual(
+      expect.objectContaining(ctx.payload)
+    );
+  });
+  it<TestContext>("throws an exception if the payload can't be verified", async (ctx) => {
+    await createSessionCookie(ctx.payload);
+    getCookie.mockImplementationOnce(() => ({
+      value: "invalid token, that cannot be verified",
+    }));
+    await expect(getPayloadFromSessionCookie()).rejects.toThrowError(
+      /unable to get/
+    );
+  });
+});

--- a/apps/io-sign-backoffice-ca/src/app/auth/_lib/__test__/user.spec.ts
+++ b/apps/io-sign-backoffice-ca/src/app/auth/_lib/__test__/user.spec.ts
@@ -1,0 +1,59 @@
+import { vi, it, expect, describe } from "vitest";
+
+import { getLoggedUser, authenticate } from "../user";
+
+const mocks = vi.hoisted(() => ({
+  user: {
+    id: "53680989-1538-40f4-932d-36a63fa1135d",
+    email: "unit+test@pagopa.it",
+    firstName: "Mario",
+    lastName: "Rossi",
+  },
+  organization: {
+    id: "53680989-1538-40f4-932d-36a63fa1135d",
+  },
+}));
+
+const { getPayloadFromSessionCookie, createSessionCookie } = vi.hoisted(() => ({
+  getPayloadFromSessionCookie: vi.fn(() => mocks.user),
+  createSessionCookie: vi.fn(),
+}));
+
+vi.mock("../session", () => ({
+  getPayloadFromSessionCookie,
+  createSessionCookie,
+}));
+
+vi.mock("../self-care", () => ({
+  verifySelfCareIdToken: vi.fn(async () => ({
+    uid: mocks.user.id,
+    email: mocks.user.email,
+    name: mocks.user.firstName,
+    family_name: mocks.user.lastName,
+    organization: mocks.organization,
+    iat: Date.now(),
+    desired_exp: Date.now() + 15 * 60 * 1000,
+  })),
+}));
+
+describe("getLoggedUser", () => {
+  it("returns the User object stored in the session cookie", async () => {
+    const user = await getLoggedUser();
+    expect(user).toEqual(mocks.user);
+  });
+  it("throws on invalid payload", async () => {
+    getPayloadFromSessionCookie.mockImplementationOnce(() => ({
+      ...mocks.user,
+      email: "unit+test",
+    }));
+    await expect(() => getLoggedUser()).rejects.toThrowError(/unauthenticated/);
+  });
+});
+
+describe("authenticate", () => {
+  it("creates a session cookie with the right payload", async () => {
+    const { institutionId } = await authenticate("my-id-tok");
+    expect(institutionId).toBe(mocks.organization.id);
+    expect(createSessionCookie).toHaveBeenCalledWith(mocks.user, 15 * 60);
+  });
+});

--- a/apps/io-sign-backoffice-ca/src/app/auth/_lib/self-care.ts
+++ b/apps/io-sign-backoffice-ca/src/app/auth/_lib/self-care.ts
@@ -1,0 +1,59 @@
+import { createRemoteJWKSet, jwtVerify } from "jose";
+import { z } from "zod";
+import { cache } from "react";
+
+const Config = z
+  .object({
+    AUTH_SELFCARE_JWK_SET_URL: z.string().url(),
+    AUTH_SELFCARE_JWT_ISSUER: z.string().nonempty(),
+    AUTH_SELFCARE_JWT_AUDIENCE: z.string().nonempty(),
+  })
+  .transform((e) => ({
+    jwks: new URL(e.AUTH_SELFCARE_JWK_SET_URL),
+    audience: e.AUTH_SELFCARE_JWT_AUDIENCE,
+    issuer: e.AUTH_SELFCARE_JWT_ISSUER,
+  }));
+
+const getConfig = cache(() => {
+  const result = Config.safeParse(process.env);
+  if (!result.success) {
+    throw new Error("error parsing auth.self-care config", {
+      cause: result.error.issues,
+    });
+  }
+  return result.data;
+});
+
+const Claims = z.object({
+  // issued at (in ms)
+  iat: z.number(),
+  uid: z.string().uuid(),
+  email: z.string().email(),
+  name: z.string().nonempty(),
+  family_name: z.string().nonempty(),
+  organization: z.object({
+    id: z.string().uuid(),
+  }),
+  // "desired_exp" is a custom claim, issued by self care
+  // that has the purpose to "syncronize" session duration
+  // between the product backoffice and the self care portal
+  desired_exp: z.number(),
+});
+
+type Claims = z.infer<typeof Claims>;
+
+export async function verifySelfCareIdToken(idToken: string): Promise<Claims> {
+  try {
+    const config = getConfig();
+    const jwks = createRemoteJWKSet(config.jwks);
+    const result = await jwtVerify(idToken, jwks, {
+      issuer: config.issuer,
+      audience: config.audience,
+    });
+    return Claims.parse(result.payload);
+  } catch (e) {
+    throw new Error("the provided id token is not valid", {
+      cause: e,
+    });
+  }
+}

--- a/apps/io-sign-backoffice-ca/src/app/auth/_lib/session.ts
+++ b/apps/io-sign-backoffice-ca/src/app/auth/_lib/session.ts
@@ -1,0 +1,75 @@
+import { cookies } from "next/headers";
+import { SignJWT, jwtVerify } from "jose";
+import { cache } from "react";
+import { z } from "zod";
+
+const defaultCookieOptions = {
+  secure: true,
+  httpOnly: true,
+  sameSite: true,
+};
+
+const cookieName = "_iosign_session";
+
+const getSecret = cache(() => {
+  const Secret = z.string().nonempty();
+  const result = Secret.safeParse(process.env.AUTH_SESSION_SECRET);
+  if (!result.success) {
+    throw new Error("error parsing the auth session secret from environment", {
+      cause: result.error.issues,
+    });
+  }
+  const secret = new TextEncoder().encode(result.data);
+  return secret;
+});
+
+/**
+ * Creats a session cookie (an http-only, secure cookie that contains an encrypted payload)
+ * @param payload
+ * @param maxAge the number of seconds until the session cookie expires
+ */
+export async function createSessionCookie(
+  payload: {},
+  maxAge: number = 15 * 60
+) {
+  const jwt = new SignJWT({ ...payload })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime(Date.now() + maxAge * 1000);
+  const secret = getSecret();
+  const value = await jwt.sign(secret);
+  cookies().set(cookieName, value, {
+    maxAge,
+    ...defaultCookieOptions,
+  });
+}
+
+export function destroySessionCookie() {
+  cookies().set(cookieName, "", {
+    maxAge: 0,
+    ...defaultCookieOptions,
+  });
+}
+
+function getSessionCookie(): { name: string; value: string } {
+  const cookie = cookies().get(cookieName);
+  if (typeof cookie === "undefined") {
+    throw new Error("unable to get the session cookie");
+  }
+  return cookie;
+}
+
+export async function getPayloadFromSessionCookie(): Promise<{}> {
+  let payload: {};
+  try {
+    const cookie = getSessionCookie();
+    const secret = getSecret();
+    const result = await jwtVerify(cookie.value, secret);
+    payload = result.payload;
+  } catch (e) {
+    throw new Error("unable to get the session cookie", {
+      cause: e,
+    });
+  }
+  return payload;
+}

--- a/apps/io-sign-backoffice-ca/src/app/auth/_lib/user.ts
+++ b/apps/io-sign-backoffice-ca/src/app/auth/_lib/user.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+import { verifySelfCareIdToken } from "./self-care";
+import { getPayloadFromSessionCookie, createSessionCookie } from "./session";
+
+export const User = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  firstName: z.string().nonempty(),
+  lastName: z.string().nonempty(),
+});
+
+export type User = z.infer<typeof User>;
+
+export class UnauthenticatedUserError extends Error {
+  constructor(e: unknown) {
+    super("unauthenticated user", {
+      cause: e,
+    });
+    this.name = "UnauthenticatedUserError";
+  }
+}
+
+export let authenticate = async (idToken: string) => {
+  const {
+    iat,
+    desired_exp,
+    uid: id,
+    email,
+    name: firstName,
+    family_name: lastName,
+    organization: { id: institutionId },
+  } = await verifySelfCareIdToken(idToken);
+  const user = {
+    id,
+    email,
+    firstName,
+    lastName,
+  };
+  const maxAge = (desired_exp - iat) / 1000;
+  await createSessionCookie(user, maxAge);
+  return { user, institutionId };
+};
+
+if (process.env.NODE_ENV === "development") {
+  authenticate = async () => {
+    const user = {
+      id: "0f6143c2-250a-410f-9da7-8040599ad4d3",
+      firstName: "Napoleone",
+      lastName: "Bonaparte",
+      email: "n.bonaparte@email.test.it",
+    };
+    await createSessionCookie(user, Date.now() + 2592000);
+    return { user, institutionId: "8c68a47b-fdbd-46e9-91df-71aa0d45043b" };
+  };
+}
+
+export const getLoggedUser = async () => {
+  try {
+    const payload = await getPayloadFromSessionCookie();
+    return User.parse(payload);
+  } catch (e) {
+    throw new UnauthenticatedUserError(e);
+  }
+};

--- a/apps/io-sign-backoffice-ca/src/app/auth/logout/route.ts
+++ b/apps/io-sign-backoffice-ca/src/app/auth/logout/route.ts
@@ -1,0 +1,11 @@
+import { destroySessionCookie } from "../_lib/session";
+
+import { redirect } from "next/navigation";
+
+import { getConfig } from "@/config";
+
+export async function GET() {
+  const config = getConfig();
+  destroySessionCookie();
+  redirect(config.selfCare.portal.logoutUrl.href);
+}

--- a/apps/io-sign-backoffice-ca/src/components/mui/index.ts
+++ b/apps/io-sign-backoffice-ca/src/components/mui/index.ts
@@ -1,0 +1,3 @@
+"use client";
+
+export * from "@mui/material";

--- a/apps/io-sign-backoffice-ca/src/config.ts
+++ b/apps/io-sign-backoffice-ca/src/config.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+import { cache } from "react";
+
+const ConfigFromEnvironment = z
+  .object({
+    SELFCARE_URL: z.string().url(),
+    SELFCARE_SUPPORT_URL: z.string().url(),
+    SELFCARE_LOGOUT_URL: z.string().url(),
+    DOCUMENTATION_URL: z.string().url(),
+  })
+  .transform((e) => ({
+    selfCare: {
+      portal: {
+        url: new URL(e.SELFCARE_URL),
+        supportUrl: new URL(e.SELFCARE_SUPPORT_URL),
+        logoutUrl: new URL(e.SELFCARE_LOGOUT_URL),
+      },
+    },
+    documentationUrl: new URL(e.DOCUMENTATION_URL),
+  }));
+
+export type Config = z.infer<typeof ConfigFromEnvironment>;
+
+export const getConfig = cache(() => {
+  const result = ConfigFromEnvironment.safeParse(process.env);
+  if (!result.success) {
+    throw new Error("error loading the config", {
+      cause: result.error.issues,
+    });
+  }
+  return result.data;
+});

--- a/apps/io-sign-backoffice-ca/src/i18n.tsx
+++ b/apps/io-sign-backoffice-ca/src/i18n.tsx
@@ -1,0 +1,10 @@
+import { getRequestConfig } from "next-intl/server";
+
+export default getRequestConfig(async ({ locale }) => ({
+  messages: (await import(`./messages/${locale}.json`)).default,
+  defaultTranslationValues: {
+    supportl3: "firmaconio-tech@pagopa.it",
+    strong: (text) => <strong>{text}</strong>,
+    email: (address) => <a href={`mailto:${address}`}>{address}</a>,
+  },
+}));

--- a/apps/io-sign-backoffice-ca/src/messages/it.json
+++ b/apps/io-sign-backoffice-ca/src/messages/it.json
@@ -1,11 +1,16 @@
 {
-  "HeaderWithAccountInfo": {
-    "rootLink": {
+  "common": {
+    "companyLink": {
       "title": "Sito di PagoPA S.p.A.",
-      "ariaLabel": "Link: vai al sito di PagoPA S.p.A."
+      "ariaLabel": "Link vai al sito di PagoPA S.p.A."
     }
   },
   "Index": {
-    "title": "Ciao!"
+    "title": "Il tuo ente ha aderito",
+    "body": "Entro qualche giorno riceverai via email le API Key e le\n indicazioni per procedere. Se hai bisogno di supporto,\n contatta il tuo referente PagoPA o scrivi a \n <email>{supportl3}</email>",
+    "cta": "Indietro"
+  },
+  "Footer": {
+    "legal": "<strong>PagoPA S.p.A.</strong> - Società per azioni con socio unico - Capitale sociale di euro 1,000,000 interamente versato - Sede legale in Roma, Piazza Colonna 370,\n CAP 00187 - N. di iscrizione a Registro Imprese di Roma, CF e P.IVA 15376371009"
   }
 }

--- a/apps/io-sign-backoffice-ca/src/middleware.ts
+++ b/apps/io-sign-backoffice-ca/src/middleware.ts
@@ -1,10 +1,10 @@
-import createMiddleware from "next-intl/middleware";
+import createIntlMiddleware from "next-intl/middleware";
 
-export default createMiddleware({
+export default createIntlMiddleware({
   locales: ["it"],
   defaultLocale: "it",
 });
 
 export const config = {
-  matcher: ["/((?!api|_next|.*\\..*).*)"],
+  matcher: ["/((?!auth|api|_next|.*\\..*).*)"],
 };

--- a/apps/io-sign-backoffice-ca/vitest.config.js
+++ b/apps/io-sign-backoffice-ca/vitest.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+import * as path from "node:path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      react: "next/dist/compiled/react",
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2904,6 +2904,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/schemas@npm:^29.6.0":
+  version: 29.6.0
+  resolution: "@jest/schemas@npm:29.6.0"
+  dependencies:
+    "@sinclair/typebox": ^0.27.8
+  checksum: c00511c69cf89138a7d974404d3a5060af375b5a52b9c87215d91873129b382ca11c1ff25bd6d605951404bb381ddce5f8091004a61e76457da35db1f5c51365
+  languageName: node
+  linkType: hard
+
 "@jest/transform@npm:^29.3.1":
   version: 29.5.0
   resolution: "@jest/transform@npm:29.5.0"
@@ -2973,7 +2982,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.13":
+"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.13, @jridgewell/sourcemap-codec@npm:^1.4.15":
   version: 1.4.15
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.15"
   checksum: b881c7e503db3fc7f3c1f35a1dd2655a188cc51a3612d76efc8a6eb74728bef5606e6758ee77423e564092b4a518aba569bbb21c9bac5ab7a35b0c6ae7e344c8
@@ -3530,10 +3539,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:13.4.8":
-  version: 13.4.8
-  resolution: "@next/env@npm:13.4.8"
-  checksum: 24e8966c9963879e7f9bab09248bebb89d8615b740dad286e0eb5f92909dddfc30e80ef9df29da757dbf50dcdf483037e65521fc9ea68582fb78d752273d4ba6
+"@next/env@npm:13.4.11":
+  version: 13.4.11
+  resolution: "@next/env@npm:13.4.11"
+  checksum: f0181ae16ba3f7bbf6e7ce9b431218740b800ab3c2a61a50a75828794eecb7e6fe324f0547bfc6d80221ab3f4b812184a040c7c72b0f37c2f0c3742047f352c6
   languageName: node
   linkType: hard
 
@@ -3576,9 +3585,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:13.4.8":
-  version: 13.4.8
-  resolution: "@next/swc-darwin-arm64@npm:13.4.8"
+"@next/swc-darwin-arm64@npm:13.4.11":
+  version: 13.4.11
+  resolution: "@next/swc-darwin-arm64@npm:13.4.11"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -3590,9 +3599,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:13.4.8":
-  version: 13.4.8
-  resolution: "@next/swc-darwin-x64@npm:13.4.8"
+"@next/swc-darwin-x64@npm:13.4.11":
+  version: 13.4.11
+  resolution: "@next/swc-darwin-x64@npm:13.4.11"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -3618,9 +3627,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:13.4.8":
-  version: 13.4.8
-  resolution: "@next/swc-linux-arm64-gnu@npm:13.4.8"
+"@next/swc-linux-arm64-gnu@npm:13.4.11":
+  version: 13.4.11
+  resolution: "@next/swc-linux-arm64-gnu@npm:13.4.11"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -3632,9 +3641,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:13.4.8":
-  version: 13.4.8
-  resolution: "@next/swc-linux-arm64-musl@npm:13.4.8"
+"@next/swc-linux-arm64-musl@npm:13.4.11":
+  version: 13.4.11
+  resolution: "@next/swc-linux-arm64-musl@npm:13.4.11"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -3646,9 +3655,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:13.4.8":
-  version: 13.4.8
-  resolution: "@next/swc-linux-x64-gnu@npm:13.4.8"
+"@next/swc-linux-x64-gnu@npm:13.4.11":
+  version: 13.4.11
+  resolution: "@next/swc-linux-x64-gnu@npm:13.4.11"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -3660,9 +3669,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:13.4.8":
-  version: 13.4.8
-  resolution: "@next/swc-linux-x64-musl@npm:13.4.8"
+"@next/swc-linux-x64-musl@npm:13.4.11":
+  version: 13.4.11
+  resolution: "@next/swc-linux-x64-musl@npm:13.4.11"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -3674,9 +3683,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:13.4.8":
-  version: 13.4.8
-  resolution: "@next/swc-win32-arm64-msvc@npm:13.4.8"
+"@next/swc-win32-arm64-msvc@npm:13.4.11":
+  version: 13.4.11
+  resolution: "@next/swc-win32-arm64-msvc@npm:13.4.11"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -3688,9 +3697,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-win32-ia32-msvc@npm:13.4.8":
-  version: 13.4.8
-  resolution: "@next/swc-win32-ia32-msvc@npm:13.4.8"
+"@next/swc-win32-ia32-msvc@npm:13.4.11":
+  version: 13.4.11
+  resolution: "@next/swc-win32-ia32-msvc@npm:13.4.11"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
@@ -3702,9 +3711,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:13.4.8":
-  version: 13.4.8
-  resolution: "@next/swc-win32-x64-msvc@npm:13.4.8"
+"@next/swc-win32-x64-msvc@npm:13.4.11":
+  version: 13.4.11
+  resolution: "@next/swc-win32-x64-msvc@npm:13.4.11"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -4023,6 +4032,13 @@ __metadata:
   version: 0.25.24
   resolution: "@sinclair/typebox@npm:0.25.24"
   checksum: 10219c58f40b8414c50b483b0550445e9710d4fe7b2c4dccb9b66533dd90ba8e024acc776026cebe81e87f06fa24b07fdd7bc30dd277eb9cc386ec50151a3026
+  languageName: node
+  linkType: hard
+
+"@sinclair/typebox@npm:^0.27.8":
+  version: 0.27.8
+  resolution: "@sinclair/typebox@npm:0.27.8"
+  checksum: 00bd7362a3439021aa1ea51b0e0d0a0e8ca1351a3d54c606b115fdcc49b51b16db6e5f43b4fe7a28c38688523e22a94d49dd31168868b655f0d4d50f032d07a1
   languageName: node
   linkType: hard
 
@@ -4975,6 +4991,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/chai@npm:^4.3.5":
+  version: 4.3.5
+  resolution: "@types/chai@npm:4.3.5"
+  checksum: c8f26a88c6b5b53a3275c7f5ff8f107028e3cbb9ff26795fff5f3d9dea07106a54ce9e2dce5e40347f7c4cc35657900aaf0c83934a25a1ae12e61e0f5516e431
+  languageName: node
+  linkType: hard
+
 "@types/clean-css@npm:*":
   version: 4.2.6
   resolution: "@types/clean-css@npm:4.2.6"
@@ -5715,6 +5738,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/expect@npm:0.33.0":
+  version: 0.33.0
+  resolution: "@vitest/expect@npm:0.33.0"
+  dependencies:
+    "@vitest/spy": 0.33.0
+    "@vitest/utils": 0.33.0
+    chai: ^4.3.7
+  checksum: da6bf8e4a4f23218088b4e7dcdf6eb9f8d92e82a98a674edf8be2f333625179da6802936a948e7a60e0918da53e7ec548183d1d9d42f0e1c4e2d3f66fd63e11f
+  languageName: node
+  linkType: hard
+
 "@vitest/runner@npm:0.30.1":
   version: 0.30.1
   resolution: "@vitest/runner@npm:0.30.1"
@@ -5724,6 +5758,17 @@ __metadata:
     p-limit: ^4.0.0
     pathe: ^1.1.0
   checksum: b8f9faa63f3e98671804ab403a1dc466a48548fa5ee5e276855f0bcc1fae528ca65476584fb5528dd62ba9865c54d147b1ae78fb0cafe337c043669dcb93e67d
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:0.33.0":
+  version: 0.33.0
+  resolution: "@vitest/runner@npm:0.33.0"
+  dependencies:
+    "@vitest/utils": 0.33.0
+    p-limit: ^4.0.0
+    pathe: ^1.1.1
+  checksum: de731aa0687cf15f141e81fb11027ff52860292f6d8957678c9fcd307502e4f9fd679bcaff93b53d29eeeb694d403d6aa52d49d341f998ec2b794e7abe061572
   languageName: node
   linkType: hard
 
@@ -5738,12 +5783,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/snapshot@npm:0.33.0":
+  version: 0.33.0
+  resolution: "@vitest/snapshot@npm:0.33.0"
+  dependencies:
+    magic-string: ^0.30.1
+    pathe: ^1.1.1
+    pretty-format: ^29.5.0
+  checksum: ff2604d5bf09342eab45109df06f4e2e9e78698bf26b0eed1f4871d7757312e43de90ead938698be3e03e9873d4081ebeb69c94928b8065c53d1e9f28742185e
+  languageName: node
+  linkType: hard
+
 "@vitest/spy@npm:0.30.1":
   version: 0.30.1
   resolution: "@vitest/spy@npm:0.30.1"
   dependencies:
     tinyspy: ^2.1.0
   checksum: af2e0a3910dfaa6b5759acd4913ca3c21ac9ad543c0d1095c23bdbca1a7d4e5dab43d8bfc4b08025d24e84965d65ae83f2cdc6aad080eaf5faf06daf06af3271
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:0.33.0":
+  version: 0.33.0
+  resolution: "@vitest/spy@npm:0.33.0"
+  dependencies:
+    tinyspy: ^2.1.1
+  checksum: 501a704a10b411f407fbcedeaf1f469e6fcac4894af11fa89c74e6f64bf3eebbcd006cf86377ae379708c0b8c860243db504f5d4e90d382419aa666458b76800
   languageName: node
   linkType: hard
 
@@ -5755,6 +5820,17 @@ __metadata:
     loupe: ^2.3.6
     pretty-format: ^27.5.1
   checksum: a685b6ba34b0173e4da388055dc2a22ba335a74cf99679f7036cea1d183e0ee804a01984148eaad0e0f48bfb786d33800ff6dd549b94f3d064e14caa0857ee62
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:0.33.0":
+  version: 0.33.0
+  resolution: "@vitest/utils@npm:0.33.0"
+  dependencies:
+    diff-sequences: ^29.4.3
+    loupe: ^2.3.6
+    pretty-format: ^29.5.0
+  checksum: 8c5b381f5599ca517bedd0e46805e91b1150564473d37b2b80ef45aa9c16cb59d296513dd34bc2171904beb28be73b89e5333056539d49a0ba9d513ae7672a0a
   languageName: node
   linkType: hard
 
@@ -8123,6 +8199,13 @@ __metadata:
   dependencies:
     semver: ^5.3.0
   checksum: 1a2d42f3e36abb870ad1b06c8563c314d48cf4ee3be14eedf07fcad119dd5d4caaafb3bcc7c970f04dbe8a54b52c271bcf8b6b9ea9ea9142bc262a1b9be3ec96
+  languageName: node
+  linkType: hard
+
+"diff-sequences@npm:^29.4.3":
+  version: 29.4.3
+  resolution: "diff-sequences@npm:29.4.3"
+  checksum: 28b265e04fdddcf7f9f814effe102cc95a9dec0564a579b5aed140edb24fc345c611ca52d76d725a3cab55d3888b915b5e8a4702e0f6058968a90fa5f41fcde7
   languageName: node
   linkType: hard
 
@@ -10990,11 +11073,13 @@ __metadata:
     "@types/react-dom": 18.2.6
     eslint: 8.44.0
     eslint-config-next: 13.4.8
-    next: 13.4.8
-    next-intl: ^2.17.5
+    jose: ^4.14.4
+    next: ^13.4.11
+    next-intl: 3.0.0-beta.8
     react: 18.2.0
     react-dom: 18.2.0
     typescript: 5.1.6
+    vitest: ^0.33.0
     zod: ^3.21.4
   languageName: unknown
   linkType: soft
@@ -11761,6 +11846,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jose@npm:^4.14.4":
+  version: 4.14.4
+  resolution: "jose@npm:4.14.4"
+  checksum: 2d820a91a8fd97c05d8bc8eedc373b944a0cd7f5fe41063086da233d0473c73fb523912a9f026ea870782bd221f4a515f441a2d3af4de48c6f2c76dac5082377
+  languageName: node
+  linkType: hard
+
 "joycon@npm:^3.0.1":
   version: 3.1.1
   resolution: "joycon@npm:3.1.1"
@@ -12467,6 +12559,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"magic-string@npm:^0.30.1":
+  version: 0.30.1
+  resolution: "magic-string@npm:0.30.1"
+  dependencies:
+    "@jridgewell/sourcemap-codec": ^1.4.15
+  checksum: 7bc7e4493e32a77068f3753bf8652d4ab44142122eb7fb9fa871af83bef2cd2c57518a6769701cd5d0379bd624a13bc8c72ca25ac5655b27e5a61adf1fd38db2
+  languageName: node
+  linkType: hard
+
 "make-dir@npm:^2.0.0, make-dir@npm:^2.1.0":
   version: 2.1.0
   resolution: "make-dir@npm:2.1.0"
@@ -13030,6 +13131,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mlly@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "mlly@npm:1.4.0"
+  dependencies:
+    acorn: ^8.9.0
+    pathe: ^1.1.1
+    pkg-types: ^1.0.3
+    ufo: ^1.1.2
+  checksum: ebf2e2b5cfb4c6e45e8d0bbe82710952247023f12626cb0997c41b1bb6e57c8b6fc113aa709228ad511382ab0b4eebaab759806be0578093b3635d3e940bd63b
+  languageName: node
+  linkType: hard
+
 "moment@npm:^2.24.0":
   version: 2.29.4
   resolution: "moment@npm:2.29.4"
@@ -13180,17 +13293,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next-intl@npm:^2.17.5":
-  version: 2.17.5
-  resolution: "next-intl@npm:2.17.5"
+"next-intl@npm:3.0.0-beta.8":
+  version: 3.0.0-beta.8
+  resolution: "next-intl@npm:3.0.0-beta.8"
   dependencies:
     "@formatjs/intl-localematcher": ^0.2.32
     negotiator: ^0.6.3
+    server-only: 0.0.1
     use-intl: ^2.17.5
   peerDependencies:
     next: ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 286d0d137e1f2916e20b2e09334aec3f8bc31a9048f27d034be66d72ca783d91c96a9c5007511fb73b0e39d13ef9f1a6311c05b83ad53038cf81f9b9953066b4
+  checksum: 734fca5e561a7ea7f1802d511c3e522257bb2d2591119ceb2d46259f397aed08b49ed57c145a9ed2fdfb5737391ec64713098b1231334a4bdde358659fc3ee36
   languageName: node
   linkType: hard
 
@@ -13265,20 +13379,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:13.4.8":
-  version: 13.4.8
-  resolution: "next@npm:13.4.8"
+"next@npm:^13.4.11":
+  version: 13.4.11
+  resolution: "next@npm:13.4.11"
   dependencies:
-    "@next/env": 13.4.8
-    "@next/swc-darwin-arm64": 13.4.8
-    "@next/swc-darwin-x64": 13.4.8
-    "@next/swc-linux-arm64-gnu": 13.4.8
-    "@next/swc-linux-arm64-musl": 13.4.8
-    "@next/swc-linux-x64-gnu": 13.4.8
-    "@next/swc-linux-x64-musl": 13.4.8
-    "@next/swc-win32-arm64-msvc": 13.4.8
-    "@next/swc-win32-ia32-msvc": 13.4.8
-    "@next/swc-win32-x64-msvc": 13.4.8
+    "@next/env": 13.4.11
+    "@next/swc-darwin-arm64": 13.4.11
+    "@next/swc-darwin-x64": 13.4.11
+    "@next/swc-linux-arm64-gnu": 13.4.11
+    "@next/swc-linux-arm64-musl": 13.4.11
+    "@next/swc-linux-x64-gnu": 13.4.11
+    "@next/swc-linux-x64-musl": 13.4.11
+    "@next/swc-win32-arm64-msvc": 13.4.11
+    "@next/swc-win32-ia32-msvc": 13.4.11
+    "@next/swc-win32-x64-msvc": 13.4.11
     "@swc/helpers": 0.5.1
     busboy: 1.6.0
     caniuse-lite: ^1.0.30001406
@@ -13320,7 +13434,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 9af39db490707b93f7354457400997423655c59af3888f4a2db15a562711adadd83c17fba562f56341e4e020b43569d86b0a5630c0811c1a97c68f01b647dfc6
+  checksum: 3d6a7443bc1f22bc98db1cb87096df1e97c511a7cb8b0ee24469ea20bcfe50ba0b2baeb7e7ad9dba4c92cc126fc6809ba7f1690510ee2f54226bfd3173b921bd
   languageName: node
   linkType: hard
 
@@ -14143,6 +14257,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "pathe@npm:1.1.1"
+  checksum: 34ab3da2e5aa832ebc6a330ffe3f73d7ba8aec6e899b53b8ec4f4018de08e40742802deb12cf5add9c73b7bf719b62c0778246bd376ca62b0fb23e0dde44b759
+  languageName: node
+  linkType: hard
+
 "pathval@npm:^1.1.1":
   version: 1.1.1
   resolution: "pathval@npm:1.1.1"
@@ -14250,6 +14371,17 @@ __metadata:
     mlly: ^1.1.1
     pathe: ^1.1.0
   checksum: 2d0a70c1721c2ebbe075b912531a4f43136e6658fdcc59dc76c39966201ab5ddf265868d1211943183406d4b70d373c17e3b176487bc2020ea737d030b0fd080
+  languageName: node
+  linkType: hard
+
+"pkg-types@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "pkg-types@npm:1.0.3"
+  dependencies:
+    jsonc-parser: ^3.2.0
+    mlly: ^1.2.0
+    pathe: ^1.1.0
+  checksum: 4b305c834b912ddcc8a0fe77530c0b0321fe340396f84cbb87aecdbc126606f47f2178f23b8639e71a4870f9631c7217aef52ffed0ae17ea2dbbe7e43d116a6e
   languageName: node
   linkType: hard
 
@@ -14407,6 +14539,17 @@ __metadata:
     ansi-styles: ^5.0.0
     react-is: ^17.0.1
   checksum: cf610cffcb793885d16f184a62162f2dd0df31642d9a18edf4ca298e909a8fe80bdbf556d5c9573992c102ce8bf948691da91bf9739bee0ffb6e79c8a8a6e088
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:^29.5.0":
+  version: 29.6.1
+  resolution: "pretty-format@npm:29.6.1"
+  dependencies:
+    "@jest/schemas": ^29.6.0
+    ansi-styles: ^5.0.0
+    react-is: ^18.0.0
+  checksum: 6f923a2379a37a425241dc223d76f671c73c4f37dba158050575a54095867d565c068b441843afdf3d7c37bed9df4bbadf46297976e60d4149972b779474203a
   languageName: node
   linkType: hard
 
@@ -14765,7 +14908,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^18.2.0":
+"react-is@npm:^18.0.0, react-is@npm:^18.2.0":
   version: 18.2.0
   resolution: "react-is@npm:18.2.0"
   checksum: e72d0ba81b5922759e4aff17e0252bd29988f9642ed817f56b25a3e217e13eea8a7f2322af99a06edb779da12d5d636e9fda473d620df9a3da0df2a74141d53e
@@ -15621,6 +15764,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"server-only@npm:0.0.1":
+  version: 0.0.1
+  resolution: "server-only@npm:0.0.1"
+  checksum: c432348956641ea3f460af8dc3765f3a1bdbcf7a1e0205b0756d868e6e6fe8934cdee6bff68401a1dd49ba4a831c75916517a877446d54b334f7de36fa273e53
+  languageName: node
+  linkType: hard
+
 "set-blocking@npm:^2.0.0":
   version: 2.0.0
   resolution: "set-blocking@npm:2.0.0"
@@ -16033,6 +16183,13 @@ __metadata:
   version: 3.3.2
   resolution: "std-env@npm:3.3.2"
   checksum: c02256bb041ba1870d23f8360bc7e47a9cf1fabcd02c8b7c4246d48f2c6bb47b4f45c70964348844e6d36521df84c4a9d09d468654b51e0eb5c600e3392b4570
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^3.3.3":
+  version: 3.3.3
+  resolution: "std-env@npm:3.3.3"
+  checksum: 6665f6d8bd63aae432d3eb9abbd7322847ad0d902603e6dce1e8051b4f42ceeb4f7f96a4faf70bb05ce65ceee2dc982502b701575c8a58b1bfad29f3dbb19f81
   languageName: node
   linkType: hard
 
@@ -16624,6 +16781,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinybench@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "tinybench@npm:2.5.0"
+  checksum: 284bb9428f197ec8b869c543181315e65e41ccfdad3c4b6c916bb1fdae1b5c6785661b0d90cf135b48d833b03cb84dc5357b2d33ec65a1f5971fae0ab2023821
+  languageName: node
+  linkType: hard
+
 "tinypool@npm:^0.4.0":
   version: 0.4.0
   resolution: "tinypool@npm:0.4.0"
@@ -16631,10 +16795,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinypool@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "tinypool@npm:0.6.0"
+  checksum: 996bf3a922993cec568d6b6ddc72531700b2a8aea24623ed6946a8929557b0f17629955d20defda09cb3b12fc94087159f14cb8e06570adce7d1b7d2eef00a91
+  languageName: node
+  linkType: hard
+
 "tinyspy@npm:^2.1.0":
   version: 2.1.0
   resolution: "tinyspy@npm:2.1.0"
   checksum: cb83c1f74a79dd5934018bad94f60a304a29d98a2d909ea45fc367f7b80b21b0a7d8135a2ce588deb2b3ba56c7c607258b2a03e6001d89e4d564f9a95cc6a81f
+  languageName: node
+  linkType: hard
+
+"tinyspy@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "tinyspy@npm:2.1.1"
+  checksum: cfe669803a7f11ca912742b84c18dcc4ceecaa7661c69bc5eb608a8a802d541c48aba220df8929f6c8cd09892ad37cb5ba5958ddbbb57940e91d04681d3cee73
   languageName: node
   linkType: hard
 
@@ -17155,6 +17333,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ufo@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "ufo@npm:1.1.2"
+  checksum: 83c940a6a23b6d4fc0cd116265bb5dcf88ab34a408ad9196e413270ca607a4781c09b547dc518f43caee128a096f20fe80b5a0e62b4bcc0a868619896106d048
+  languageName: node
+  linkType: hard
+
 "uglify-js@npm:^3.1.4, uglify-js@npm:^3.5.1":
   version: 3.17.4
   resolution: "uglify-js@npm:3.17.4"
@@ -17662,6 +17847,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite-node@npm:0.33.0":
+  version: 0.33.0
+  resolution: "vite-node@npm:0.33.0"
+  dependencies:
+    cac: ^6.7.14
+    debug: ^4.3.4
+    mlly: ^1.4.0
+    pathe: ^1.1.1
+    picocolors: ^1.0.0
+    vite: ^3.0.0 || ^4.0.0
+  bin:
+    vite-node: vite-node.mjs
+  checksum: 7c37911251d3e318fe4ad6b4093207498336ce190a58afb43a9ae701eee7f110ef80920b79061710cf6abcc6335ce58f6ca412ee6b268f25fe10f278c94cc264
+  languageName: node
+  linkType: hard
+
 "vite@npm:^3.0.0 || ^4.0.0":
   version: 4.2.1
   resolution: "vite@npm:4.2.1"
@@ -17796,6 +17997,66 @@ __metadata:
   bin:
     vitest: vitest.mjs
   checksum: 68e33226dde914600270df9834bdc1f45fd225250051c046c9bc53ca51b8e0bf76dee29a5cf1a51a4c1524f00c414f81764bb463734bdcc9c3f483f2140ec516
+  languageName: node
+  linkType: hard
+
+"vitest@npm:^0.33.0":
+  version: 0.33.0
+  resolution: "vitest@npm:0.33.0"
+  dependencies:
+    "@types/chai": ^4.3.5
+    "@types/chai-subset": ^1.3.3
+    "@types/node": "*"
+    "@vitest/expect": 0.33.0
+    "@vitest/runner": 0.33.0
+    "@vitest/snapshot": 0.33.0
+    "@vitest/spy": 0.33.0
+    "@vitest/utils": 0.33.0
+    acorn: ^8.9.0
+    acorn-walk: ^8.2.0
+    cac: ^6.7.14
+    chai: ^4.3.7
+    debug: ^4.3.4
+    local-pkg: ^0.4.3
+    magic-string: ^0.30.1
+    pathe: ^1.1.1
+    picocolors: ^1.0.0
+    std-env: ^3.3.3
+    strip-literal: ^1.0.1
+    tinybench: ^2.5.0
+    tinypool: ^0.6.0
+    vite: ^3.0.0 || ^4.0.0
+    vite-node: 0.33.0
+    why-is-node-running: ^2.2.2
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@vitest/browser": "*"
+    "@vitest/ui": "*"
+    happy-dom: "*"
+    jsdom: "*"
+    playwright: "*"
+    safaridriver: "*"
+    webdriverio: "*"
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@vitest/browser":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+    playwright:
+      optional: true
+    safaridriver:
+      optional: true
+    webdriverio:
+      optional: true
+  bin:
+    vitest: vitest.mjs
+  checksum: c1884b2a1a41af81ee54c86a986a32b6a4c69ec3b3f7d2322f92c8fad5532d6a12160e7efb7927e4c53d95806ef4ede9549bdd82c66604e281c71056212f56e7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. Added `/auth/[id]` and `/auth/logout` routes to manage authentication. The first one verifies the id token passed by self care portal and creates a sealed session cookie (like [the ones in ruby on rails](https://guides.rubyonrails.org/security.html#session-storage) ) based on jwt, the second route destroys the cookie.
2. Improved translation, now they are totally server-side driven. No more `messages.json` in `bundle.js` and delays/FUOC while resolving the translations.
3. Improved the main header with documentation, support and logout button. Added the footer.
4. Added a proper home page!
5. Revamped the project structure, to use a more "idiomatic" style for Next.js and React standards.

With this changes we are now able to deploy safely this service in production :) 

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

The authentication part is fully unit-tested with jest. There are not E2E tests for now.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

![image](https://github.com/pagopa/io-sign/assets/4357400/a968c6d5-20df-4ae7-b979-76c767ada507)


#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
