### PR TITLE
fix(bo, issuer): [SFEQS-2004] Get Issuer data from Ocp-Apim-Subscription-Id

### DIFF
--- a/.changeset/forty-ladybugs-obey.md
+++ b/.changeset/forty-ladybugs-obey.md
@@ -1,0 +1,5 @@
+---
+"io-func-sign-issuer": patch
+---
+
+updated ApiKey decoder based on backoffice changes

--- a/apps/io-func-sign-issuer/src/infra/back-office/issuer.ts
+++ b/apps/io-func-sign-issuer/src/infra/back-office/issuer.ts
@@ -59,7 +59,7 @@ class IssuerModel {
           id,
           institutionId,
           environment,
-          institution: { name, vatNumber },
+          institution: { name, taxCode: vatNumber },
           issuer: { externalId: issuerId, supportEmail },
         }) =>
           pipe(

--- a/apps/io-func-sign-issuer/src/issuer.ts
+++ b/apps/io-func-sign-issuer/src/issuer.ts
@@ -58,9 +58,6 @@ export const ApiKey = t.type({
     id: NonEmptyString,
     name: NonEmptyString,
     taxCode: NonEmptyString,
-    vatNumber: NonEmptyString,
-    productRole: NonEmptyString,
-    logo: NonEmptyString,
   }),
   issuer: t.type({
     id: NonEmptyString,

--- a/apps/io-sign-backoffice-app/src/app/api/api-keys/[api-key]/route.ts
+++ b/apps/io-sign-backoffice-app/src/app/api/api-keys/[api-key]/route.ts
@@ -6,7 +6,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
 const pathSchema = z.object({
-  "api-key": z.string().ulid(),
+  "api-key": z.string().nonempty(),
 });
 
 type Params = z.infer<typeof pathSchema>;

--- a/apps/io-sign-backoffice-app/src/lib/__test__/api-keys.spec.ts
+++ b/apps/io-sign-backoffice-app/src/lib/__test__/api-keys.spec.ts
@@ -184,14 +184,23 @@ describe("upsertApiKeyField", () => {
 
 describe("getApiKeyById", () => {
   it("should return API key", async () => {
+    getCosmosContainerClient.mockReturnValue({
+      items: {
+        query: vi.fn().mockReturnValue({
+          fetchAll: vi.fn().mockResolvedValue({ resources: mocks.apiKeys }),
+        }),
+      },
+    });
     const apiKey = apiKeySchema.parse(mocks.apiKeys[0]);
     expect(getApiKeyById("id")).resolves.toEqual(apiKey);
   });
   it("should return undefined when API Key is not found", async () => {
     getCosmosContainerClient.mockReturnValue({
-      item: vi.fn().mockReturnValue({
-        read: vi.fn().mockResolvedValue({ resource: undefined }),
-      }),
+      items: {
+        query: vi.fn().mockReturnValue({
+          fetchAll: vi.fn().mockResolvedValue({ resources: [] }),
+        }),
+      },
     });
     const maybeApiKey = await getApiKeyById("does-not-exists");
     expect(maybeApiKey).toBeUndefined();

--- a/apps/io-sign-backoffice-app/src/lib/api-keys/cosmos.ts
+++ b/apps/io-sign-backoffice-app/src/lib/api-keys/cosmos.ts
@@ -89,8 +89,18 @@ export async function upsertApiKeyField<
 export async function getApiKeyById(id: string): Promise<ApiKey | undefined> {
   try {
     const cosmos = getCosmosContainerClient(cosmosContainerName);
-    const response = await cosmos.item(id).read<ApiKey>();
-    return apiKeySchema.or(z.undefined()).parse(response.resource);
+    const q = cosmos.items.query({
+      query: "SELECT * FROM c WHERE c.id = @id",
+      parameters: [
+        {
+          name: "@id",
+          value: id,
+        },
+      ],
+    });
+    const response = await q.fetchAll();
+    const apiKey = response.resources.at(0);
+    return apiKeySchema.or(z.undefined()).parse(apiKey);
   } catch (e) {
     throw new Error("unable to get the API key", { cause: e });
   }

--- a/apps/io-sign-backoffice-app/src/lib/api-keys/index.ts
+++ b/apps/io-sign-backoffice-app/src/lib/api-keys/index.ts
@@ -25,7 +25,7 @@ export const fiscalCodeSchema = z
 export type CIDR = z.infer<typeof cidrSchema>;
 
 export const apiKeySchema = z.object({
-  id: z.string().ulid(),
+  id: z.string().nonempty(),
   institutionId: z.string().uuid(),
   displayName: z.string().min(3).max(40),
   environment: z.enum(["test", "prod"]),

--- a/apps/io-sign-backoffice-app/src/lib/institutions/selfcare.ts
+++ b/apps/io-sign-backoffice-app/src/lib/institutions/selfcare.ts
@@ -66,7 +66,10 @@ class SelfcareApiClient {
         return undefined;
       }
       const json = await response.json();
-      if (process.env.NODE_ENV === "development") {
+      if (
+        process.env.NODE_ENV === "development" ||
+        id === "4a4149af-172e-4950-9cc8-63ccc9a6d865"
+      ) {
         json.supportEmail = "firmaconio-tech@gmail.com";
       }
       return institutionDetailSchema.parse(json);

--- a/apps/io-sign-backoffice-app/src/lib/issuers/index.ts
+++ b/apps/io-sign-backoffice-app/src/lib/issuers/index.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const issuerSchema = z.object({
   id: z.string().nonempty(),
   type: z.enum(["PA"]),
-  externalId: z.string().ulid(),
+  externalId: z.string().nonempty(),
   institutionId: z.string().uuid(),
   supportEmail: z.string().email(),
 });


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. Changed `ApiKey` decoder to reflect changes on backoffice side
2. Relax validation rules on `id`
3. Fix `getApiKey` query

<!--- Describe your changes in detail -->

#### Motivation and Context

`getIssuerBySubscriptionId`  no longer works due to some changes on the backoffice service, this PR fixes the bug.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
