### PR TITLE
feat: [SFEQS-1889] Add "x-firmaconio-environment" header in io-sign-user-func responses

### DIFF
--- a/.changeset/five-dolls-prove.md
+++ b/.changeset/five-dolls-prove.md
@@ -1,0 +1,5 @@
+---
+"io-func-sign-user": minor
+---
+
+add x-firmaconio-environment header to http responses related to signature requests

--- a/apps/io-func-sign-user/openapi.yaml
+++ b/apps/io-func-sign-user/openapi.yaml
@@ -249,6 +249,11 @@ paths:
       responses:
         "200":
           description: The Signature Request detail
+          headers:
+            x-firmaconio-environment:
+              schema:
+                $ref: "#/components/schemas/Environment"
+              description: The environment to which the signature request belongs.
           content:
             application/json:
               schema:
@@ -306,6 +311,11 @@ paths:
       responses:
         "200":
           description: The Third Party message detail
+          headers:
+            x-firmaconio-environment:
+              schema:
+                $ref: "#/components/schemas/Environment"
+              description: The environment to which the signature request belongs.
           content:
             application/json:
               schema:
@@ -960,3 +970,7 @@ components:
       enum:
         - TEST
         - DEFAULT
+
+    Environment:
+      type: string
+      enum: ["test", "prod"]

--- a/apps/io-func-sign-user/src/infra/azure/functions/get-third-party-message-details.ts
+++ b/apps/io-func-sign-user/src/infra/azure/functions/get-third-party-message-details.ts
@@ -3,6 +3,7 @@ import * as TE from "fp-ts/lib/TaskEither";
 
 import * as azure from "handler-kit-legacy/lib/azure";
 import { createHandler } from "handler-kit-legacy";
+import { withHeader } from "handler-kit-legacy/lib/http";
 
 import { Database } from "@azure/cosmos";
 
@@ -14,7 +15,11 @@ import { makeGetSignatureRequest } from "../cosmos/signature-request";
 import { makeRequireSignatureRequestByFiscalCode } from "../../http/decoders/signature-request";
 import { SignatureRequestToThirdPartyMessage } from "../../http/encoders/signature-request";
 import { ThirdPartyMessage } from "../../http/models/ThirdPartyMessage";
-import { signedNoMoreThan90DaysAgo } from "../../../signature-request";
+import {
+  getEnvironment,
+  signedNoMoreThan90DaysAgo,
+} from "../../../signature-request";
+import { SignatureRequestSigned } from "@io-sign/io-sign/signature-request";
 
 const makeGetThirdPartyMessageDetailsHandler = (
   pdvTokenizerClientWithApiKey: PdvTokenizerClientWithApiKey,
@@ -38,10 +43,12 @@ const makeGetThirdPartyMessageDetailsHandler = (
     TE.chain(requireSignatureRequestByFiscalCode)
   );
 
-  const encodeHttpSuccessResponse = flow(
-    SignatureRequestToThirdPartyMessage.encode,
-    success(ThirdPartyMessage)
-  );
+  const encodeHttpSuccessResponse = (request: SignatureRequestSigned) =>
+    pipe(
+      SignatureRequestToThirdPartyMessage.encode(request),
+      success(ThirdPartyMessage),
+      withHeader("x-firmaconio-environment", getEnvironment(request))
+    );
 
   return createHandler(
     decodeHttpRequest,

--- a/apps/io-func-sign-user/src/infra/http/handlers/__test__/get-signature-request.spec.ts
+++ b/apps/io-func-sign-user/src/infra/http/handlers/__test__/get-signature-request.spec.ts
@@ -141,6 +141,7 @@ describe("GetSignatureRequestHandler", () => {
           statusCode: 200,
           headers: expect.objectContaining({
             "Content-Type": "application/json",
+            "x-firmaconio-environment": "test",
           }),
         }),
       })

--- a/apps/io-func-sign-user/src/infra/http/handlers/get-signature-request.ts
+++ b/apps/io-func-sign-user/src/infra/http/handlers/get-signature-request.ts
@@ -13,6 +13,7 @@ import { toDocumentWithSasUrl } from "@io-sign/io-sign/infra/azure/storage/docum
 import { logErrorAndReturnResponse } from "@io-sign/io-sign/infra/http/utils";
 import {
   SignatureRequest,
+  getEnvironment,
   getSignatureRequest,
 } from "../../../signature-request";
 import { SignatureRequestToApiModel } from "../../http/encoders/signature-request";
@@ -46,7 +47,13 @@ export const GetSignatureRequestHandler = H.of((req: H.HttpRequest) =>
       getSignatureRequest(signatureRequestId, signerId.id)
     ),
     RTE.chainW(grantReadAccessToDocuments),
-    RTE.map(flow(SignatureRequestToApiModel.encode, H.successJson)),
+    RTE.map((request) =>
+      pipe(
+        SignatureRequestToApiModel.encode(request),
+        H.successJson,
+        H.withHeader("x-firmaconio-environment", getEnvironment(request))
+      )
+    ),
     RTE.orElseW(logErrorAndReturnResponse)
   )
 );

--- a/apps/io-func-sign-user/src/signature-request.ts
+++ b/apps/io-func-sign-user/src/signature-request.ts
@@ -291,3 +291,6 @@ export const signedNoMoreThan90DaysAgo = (
       )
     )
   );
+
+export const getEnvironment = (request: SignatureRequest) =>
+  request.issuerEnvironment === "TEST" ? "test" : "prod";


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

the following endpoints:
- `/signature-requests/{id}` 
- `/messages/{signature_request_id}`

now include the `x-firmaconio-environment` header in their responses, this header represent the `environment` in which the signature requests subject of the request belongs.

<!--- Describe your changes in detail -->

#### Motivation and Context

this header enable us to discriminate the environment on client side to include additional context on mixpanel events

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

unit tested and e2e tested manually

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

```shell
curl http://localhost:7072/api/v1/sign/signature-requests/01H07KT8QCJDMPSGDHMDR8AC70 -H "x-iosign-signer-id: 81423c92-3b3e-4024-b7f3-8b2a4ca84cd3" -v
*   Trying 127.0.0.1:7072...
* Connected to localhost (127.0.0.1) port 7072 (#0)
> GET /api/v1/sign/signature-requests/01H07KT8QCJDMPSGDHMDR8AC70 HTTP/1.1
> Host: localhost:7072
> User-Agent: curl/8.1.2
> Accept: */*
> x-iosign-signer-id: 81423c92-3b3e-4024-b7f3-8b2a4ca84cd3
> 
< HTTP/1.1 200 OK
< Content-Type: application/json; charset=utf-8
< Date: Wed, 27 Sep 2023 10:09:35 GMT
< Server: Kestrel
< Transfer-Encoding: chunked
< Content-Security-Policy: default-src 'none'; upgrade-insecure-requests
[...]
< x-firmaconio-environment: test
< 
{
  "id": "01H07KT8QCJDMPSGDHMDR8AC70",
  "signer_id": "81423c92-3b3e-4024-b7f3-8b2a4ca84cd3",
  "dossier_id": "01H07KSYMBG08WN6B8KPADWP1E",
  "dossier_title": "Carta d'identità",
  "...": "...",
}
```

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
