### PR TITLE
fix(user): [SFEQS-1889] change environment header

### DIFF
--- a/apps/io-func-sign-user/openapi.yaml
+++ b/apps/io-func-sign-user/openapi.yaml
@@ -250,7 +250,7 @@ paths:
         "200":
           description: The Signature Request detail
           headers:
-            x-firmaconio-environment:
+            x-io-sign-environment:
               schema:
                 $ref: "#/components/schemas/Environment"
               description: The environment to which the signature request belongs.
@@ -311,11 +311,6 @@ paths:
       responses:
         "200":
           description: The Third Party message detail
-          headers:
-            x-firmaconio-environment:
-              schema:
-                $ref: "#/components/schemas/Environment"
-              description: The environment to which the signature request belongs.
           content:
             application/json:
               schema:

--- a/apps/io-func-sign-user/src/infra/azure/functions/get-third-party-message-details.ts
+++ b/apps/io-func-sign-user/src/infra/azure/functions/get-third-party-message-details.ts
@@ -3,7 +3,6 @@ import * as TE from "fp-ts/lib/TaskEither";
 
 import * as azure from "handler-kit-legacy/lib/azure";
 import { createHandler } from "handler-kit-legacy";
-import { withHeader } from "handler-kit-legacy/lib/http";
 
 import { Database } from "@azure/cosmos";
 
@@ -11,15 +10,11 @@ import { PdvTokenizerClientWithApiKey } from "@io-sign/io-sign/infra/pdv-tokeniz
 import { makeGetSignerByFiscalCode } from "@io-sign/io-sign/infra/pdv-tokenizer/signer";
 import { error, success } from "@io-sign/io-sign/infra/http/response";
 
-import { SignatureRequestSigned } from "@io-sign/io-sign/signature-request";
 import { makeGetSignatureRequest } from "../cosmos/signature-request";
 import { makeRequireSignatureRequestByFiscalCode } from "../../http/decoders/signature-request";
 import { SignatureRequestToThirdPartyMessage } from "../../http/encoders/signature-request";
 import { ThirdPartyMessage } from "../../http/models/ThirdPartyMessage";
-import {
-  getEnvironment,
-  signedNoMoreThan90DaysAgo,
-} from "../../../signature-request";
+import { signedNoMoreThan90DaysAgo } from "../../../signature-request";
 
 const makeGetThirdPartyMessageDetailsHandler = (
   pdvTokenizerClientWithApiKey: PdvTokenizerClientWithApiKey,
@@ -43,12 +38,10 @@ const makeGetThirdPartyMessageDetailsHandler = (
     TE.chain(requireSignatureRequestByFiscalCode)
   );
 
-  const encodeHttpSuccessResponse = (request: SignatureRequestSigned) =>
-    pipe(
-      SignatureRequestToThirdPartyMessage.encode(request),
-      success(ThirdPartyMessage),
-      withHeader("x-firmaconio-environment", getEnvironment(request))
-    );
+  const encodeHttpSuccessResponse = flow(
+    SignatureRequestToThirdPartyMessage.encode,
+    success(ThirdPartyMessage)
+  );
 
   return createHandler(
     decodeHttpRequest,

--- a/apps/io-func-sign-user/src/infra/http/handlers/__test__/get-signature-request.spec.ts
+++ b/apps/io-func-sign-user/src/infra/http/handlers/__test__/get-signature-request.spec.ts
@@ -141,7 +141,7 @@ describe("GetSignatureRequestHandler", () => {
           statusCode: 200,
           headers: expect.objectContaining({
             "Content-Type": "application/json",
-            "x-firmaconio-environment": "test",
+            "x-io-sign-environment": "test",
           }),
         }),
       })

--- a/apps/io-func-sign-user/src/infra/http/handlers/get-signature-request.ts
+++ b/apps/io-func-sign-user/src/infra/http/handlers/get-signature-request.ts
@@ -51,7 +51,7 @@ export const GetSignatureRequestHandler = H.of((req: H.HttpRequest) =>
       pipe(
         SignatureRequestToApiModel.encode(request),
         H.successJson,
-        H.withHeader("x-firmaconio-environment", getEnvironment(request))
+        H.withHeader("x-io-sign-environment", getEnvironment(request))
       )
     ),
     RTE.orElseW(logErrorAndReturnResponse)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. renamed `x-firmaconio-environment` to `x-io-sign-environment` to make it uniform with the rest of the IO platform
2. removed this header from `/messages` endpoint

<!--- Describe your changes in detail -->

#### Motivation and Context

the `/message` endpoint should adhere to a "strict interface" that does not support additional headers

<!--- Why is this change required? What problem does it solve? -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
