### PR TITLE
fix(bo): [SFEQS-2048] fix getCosmosClient

### DIFF
--- a/apps/io-sign-backoffice-app/src/lib/cosmos.ts
+++ b/apps/io-sign-backoffice-app/src/lib/cosmos.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 import { CosmosClient } from "@azure/cosmos";
 import { cache } from "react";
 
+let cosmosClient: CosmosClient;
+
 const Config = z
   .object({
     COSMOS_DB_CONNECTION_STRING: z.string().nonempty(),
@@ -22,9 +24,12 @@ const getCosmosConfig = cache(() => {
   return result.data;
 });
 
-const getCosmosClient = cache(
-  () => new CosmosClient(getCosmosConfig().cosmosDbConnectionString)
-);
+const getCosmosClient = () => {
+  if (!cosmosClient) {
+    cosmosClient = new CosmosClient(getCosmosConfig().cosmosDbConnectionString);
+  }
+  return cosmosClient;
+};
 
 export const getCosmosContainerClient = (cosmosContainerName: string) => {
   const { cosmosDbName } = getCosmosConfig();


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. `getCosmosClient` now acts as a singleton

<!--- Describe your changes in detail -->

#### Motivation and Context

the actual implementation does not reuse the instantiated client, so maybe it's the cause of the memory leak in production

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
