### PR TITLE
chore(io-services): [SFEQS-2077] Switch to ADVANCED messages

### DIFF
--- a/.changeset/modern-penguins-speak.md
+++ b/.changeset/modern-penguins-speak.md
@@ -1,0 +1,5 @@
+---
+"@io-sign/io-sign": patch
+---
+
+submitMessageForUser now sends ADVANCED messages

--- a/packages/io-sign/src/infra/io-services/message.ts
+++ b/packages/io-sign/src/infra/io-services/message.ts
@@ -76,7 +76,7 @@ export const makeSubmitMessageForUser =
                  * in any case we are enabled to use the attachments feature.
                  * The user associated with the service has been added to a particular group (ApiThirdPartyMessageWrite) on the APIM.
                  */
-                feature_level_type: FeatureLevelTypeEnum.STANDARD,
+                feature_level_type: FeatureLevelTypeEnum.ADVANCED,
               },
             }),
           E.toError


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
`submitMessageForUser` now submits `ADVANCED` messages instead of `STANDARD` ones

<!--- Describe your changes in detail -->

#### Motivation and Context
From **Monday 18 December 2023**, to send messages with attachments, it's mandatory to set `feature_level_type` as `ADVANCED`. Reference https://github.com/pagopa/io-functions-services/pull/291
