### PR TITLE
chore(io-services): [SFEQS-2091] Set configurationId in submitMessage

### DIFF
--- a/.changeset/ninety-needles-sleep.md
+++ b/.changeset/ninety-needles-sleep.md
@@ -1,0 +1,6 @@
+---
+"io-func-sign-issuer": patch
+"@io-sign/io-sign": patch
+---
+
+Add configuration_id to submitMessageforUserWithFiscalCodeInBody

--- a/apps/io-func-sign-issuer/local.settings.json.example
+++ b/apps/io-func-sign-issuer/local.settings.json.example
@@ -11,6 +11,7 @@
     "AnalyticsEventHubConnectionString": "ANALYTICS_EVENT_HUB_CONNECTION_STRING",
     "IoServicesApiBasePath": "IO_SERVICES_API_URL",
     "IoServicesSubscriptionKey": "IO_SERVICES_API_SUBSCRIPTION_KEY",
+    "IoServicesConfigurationId": "IO_SERVICES_CONFIGURATION_ID",
     "PdvTokenizerApiBasePath": "PDV_TOKENIZER_SERVICES_API_URL",
     "PdvTokenizerApiKey": "PDV_TOKENIZER_SERVICES_API_KEY",
     "SelfCareEventHubConnectionString": "SELF_CARE_EVENT_HUB_CONNECTION_STRING",

--- a/apps/io-func-sign-issuer/src/app/main.ts
+++ b/apps/io-func-sign-issuer/src/app/main.ts
@@ -125,6 +125,7 @@ export const MarkAsRejected = makeRequestAsRejectedFunction(
   database,
   pdvTokenizerClientWithApiKey,
   ioApiClient,
+  config.pagopa.ioServices.configurationId,
   eventAnalyticsClient
 );
 
@@ -132,6 +133,7 @@ export const MarkAsSigned = makeRequestAsSignedFunction(
   database,
   pdvTokenizerClientWithApiKey,
   ioApiClient,
+  config.pagopa.ioServices.configurationId,
   eventHubBillingClient,
   eventAnalyticsClient
 );
@@ -150,6 +152,7 @@ export const SendNotification = makeSendNotificationFunction(
   database,
   pdvTokenizerClientWithApiKey,
   ioApiClient,
+  config.pagopa.ioServices.configurationId,
   eventAnalyticsClient
 );
 

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/mark-as-rejected.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/mark-as-rejected.ts
@@ -20,11 +20,13 @@ import {
   makeUpsertSignatureRequest,
 } from "../cosmos/signature-request";
 import { makeGetDossier } from "../cosmos/dossier";
+import { Ulid } from "@pagopa/ts-commons/lib/strings";
 
 const makeRequestAsRejectedHandler = (
   db: Database,
   tokenizer: PdvTokenizerClientWithApiKey,
   ioApiClient: IOApiClient,
+  configurationId: Ulid,
   eventHubAnalyticsClient: EventHubProducerClient
 ) => {
   const getSignatureRequestFromQueue = flow(
@@ -34,7 +36,7 @@ const makeRequestAsRejectedHandler = (
   const getDossier = makeGetDossier(db);
   const getSignatureRequest = makeGetSignatureRequest(db);
   const upsertSignatureRequest = makeUpsertSignatureRequest(db);
-  const submitMessage = makeSubmitMessageForUser(ioApiClient);
+  const submitMessage = makeSubmitMessageForUser(ioApiClient, configurationId);
   const getFiscalCodeBySignerId = makeGetFiscalCodeBySignerId(tokenizer);
   const createAndSendAnalyticsEvent = makeCreateAndSendAnalyticsEvent(
     eventHubAnalyticsClient

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/mark-as-rejected.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/mark-as-rejected.ts
@@ -14,13 +14,13 @@ import { IOApiClient } from "@io-sign/io-sign/infra/io-services/client";
 import { PdvTokenizerClientWithApiKey } from "@io-sign/io-sign/infra/pdv-tokenizer/client";
 import { makeCreateAndSendAnalyticsEvent } from "@io-sign/io-sign/infra/azure/event-hubs/event";
 import { EventHubProducerClient } from "@azure/event-hubs";
+import { Ulid } from "@pagopa/ts-commons/lib/strings";
 import { makeMarkRequestAsRejected } from "../../../app/use-cases/mark-request-rejected";
 import {
   makeGetSignatureRequest,
   makeUpsertSignatureRequest,
 } from "../cosmos/signature-request";
 import { makeGetDossier } from "../cosmos/dossier";
-import { Ulid } from "@pagopa/ts-commons/lib/strings";
 
 const makeRequestAsRejectedHandler = (
   db: Database,

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/mark-as-signed.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/mark-as-signed.ts
@@ -17,13 +17,13 @@ import {
   makeCreateAndSendAnalyticsEvent,
   makeSendEvent,
 } from "@io-sign/io-sign/infra/azure/event-hubs/event";
+import { Ulid } from "@pagopa/ts-commons/lib/strings";
 import {
   makeGetSignatureRequest,
   makeUpsertSignatureRequest,
 } from "../cosmos/signature-request";
 import { makeMarkRequestAsSigned } from "../../../app/use-cases/mark-request-signed";
 import { makeGetDossier } from "../cosmos/dossier";
-import { Ulid } from "@pagopa/ts-commons/lib/strings";
 
 const makeRequestAsSignedHandler = (
   db: Database,

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/mark-as-signed.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/mark-as-signed.ts
@@ -23,11 +23,13 @@ import {
 } from "../cosmos/signature-request";
 import { makeMarkRequestAsSigned } from "../../../app/use-cases/mark-request-signed";
 import { makeGetDossier } from "../cosmos/dossier";
+import { Ulid } from "@pagopa/ts-commons/lib/strings";
 
 const makeRequestAsSignedHandler = (
   db: Database,
   tokenizer: PdvTokenizerClientWithApiKey,
   ioApiClient: IOApiClient,
+  configurationId: Ulid,
   eventHubBillingClient: EventHubProducerClient,
   eventHubAnalyticsClient: EventHubProducerClient
 ) => {
@@ -38,7 +40,7 @@ const makeRequestAsSignedHandler = (
   const getDossier = makeGetDossier(db);
   const getSignatureRequest = makeGetSignatureRequest(db);
   const upsertSignatureRequest = makeUpsertSignatureRequest(db);
-  const submitMessage = makeSubmitMessageForUser(ioApiClient);
+  const submitMessage = makeSubmitMessageForUser(ioApiClient, configurationId);
   const getFiscalCodeBySignerId = makeGetFiscalCodeBySignerId(tokenizer);
 
   const sendBillingEvent = makeSendEvent(eventHubBillingClient);

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/send-notification.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/send-notification.ts
@@ -17,6 +17,7 @@ import { makeGetFiscalCodeBySignerId } from "@io-sign/io-sign/infra/pdv-tokenize
 
 import { makeCreateAndSendAnalyticsEvent } from "@io-sign/io-sign/infra/azure/event-hubs/event";
 import { EventHubProducerClient } from "@azure/event-hubs";
+import { Ulid } from "@pagopa/ts-commons/lib/strings";
 import { NotificationDetailView } from "../../http/models/NotificationDetailView";
 
 import {
@@ -32,7 +33,6 @@ import { makeGetIssuerBySubscriptionId } from "../../back-office/issuer";
 import { makeRequireIssuer } from "../../http/decoders/issuer";
 import { makeGetDossier } from "../cosmos/dossier";
 import { SendNotificationPayload } from "../../../signature-request-notification";
-import { Ulid } from "@pagopa/ts-commons/lib/strings";
 
 const makeSendNotificationHandler = (
   db: CosmosDatabase,

--- a/apps/io-func-sign-issuer/src/infra/azure/functions/send-notification.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/functions/send-notification.ts
@@ -32,17 +32,19 @@ import { makeGetIssuerBySubscriptionId } from "../../back-office/issuer";
 import { makeRequireIssuer } from "../../http/decoders/issuer";
 import { makeGetDossier } from "../cosmos/dossier";
 import { SendNotificationPayload } from "../../../signature-request-notification";
+import { Ulid } from "@pagopa/ts-commons/lib/strings";
 
 const makeSendNotificationHandler = (
   db: CosmosDatabase,
   tokenizer: PdvTokenizerClientWithApiKey,
   ioApiClient: IOApiClient,
+  configurationId: Ulid,
   eventHubAnalyticsClient: EventHubProducerClient
 ) => {
   const getSignatureRequest = makeGetSignatureRequest(db);
   const upsertSignatureRequest = makeUpsertSignatureRequest(db);
   const getIssuerBySubscriptionId = makeGetIssuerBySubscriptionId(db);
-  const submitMessage = makeSubmitMessageForUser(ioApiClient);
+  const submitMessage = makeSubmitMessageForUser(ioApiClient, configurationId);
   const getFiscalCodeBySignerId = makeGetFiscalCodeBySignerId(tokenizer);
   const getDossier = makeGetDossier(db);
   const createAndSendAnalyticsEvent = makeCreateAndSendAnalyticsEvent(

--- a/packages/io-sign/package.json
+++ b/packages/io-sign/package.json
@@ -21,7 +21,7 @@
     "@azure/storage-queue": "^12.11.0",
     "@pagopa/handler-kit": "^1.1.0",
     "@pagopa/io-functions-commons": "^26.2.1",
-    "@pagopa/io-functions-services-sdk": "^3.27.0",
+    "@pagopa/io-functions-services-sdk": "^3.39.1",
     "@pagopa/logger": "1.0.1",
     "@pagopa/ts-commons": "^10.14.2",
     "date-fns": "^2.29.3",

--- a/packages/io-sign/src/infra/io-services/config.ts
+++ b/packages/io-sign/src/infra/io-services/config.ts
@@ -1,12 +1,17 @@
 import * as t from "io-ts";
 
 import * as RE from "fp-ts/lib/ReaderEither";
+import { pipe } from "fp-ts/lib/function";
+
 import { sequenceS } from "fp-ts/lib/Apply";
 import { readFromEnvironment } from "../env";
+import { Ulid } from "@pagopa/ts-commons/lib/strings";
+import { validate } from "../../validation";
 
 export const IOServicesConfig = t.type({
   basePath: t.string,
   subscriptionKey: t.string,
+  configurationId: Ulid,
 });
 
 type IOServicesConfig = t.TypeOf<typeof IOServicesConfig>;
@@ -19,4 +24,8 @@ export const getIoServicesConfigFromEnvironment: RE.ReaderEither<
   basePath: readFromEnvironment("IoServicesApiBasePath"),
   subscriptionKey: readFromEnvironment("IoServicesSubscriptionKey"),
   requestTimeout: RE.right(1000),
+  configurationId: pipe(
+    readFromEnvironment("IoServicesConfigurationId"),
+    RE.chainEitherKW(validate(Ulid))
+  ),
 });

--- a/packages/io-sign/src/infra/io-services/config.ts
+++ b/packages/io-sign/src/infra/io-services/config.ts
@@ -4,8 +4,8 @@ import * as RE from "fp-ts/lib/ReaderEither";
 import { pipe } from "fp-ts/lib/function";
 
 import { sequenceS } from "fp-ts/lib/Apply";
-import { readFromEnvironment } from "../env";
 import { Ulid } from "@pagopa/ts-commons/lib/strings";
+import { readFromEnvironment } from "../env";
 import { validate } from "../../validation";
 
 export const IOServicesConfig = t.type({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3561,7 +3561,7 @@ __metadata:
     "@pagopa/eslint-config": ^3.0.0
     "@pagopa/handler-kit": ^1.1.0
     "@pagopa/io-functions-commons": ^26.2.1
-    "@pagopa/io-functions-services-sdk": ^3.27.0
+    "@pagopa/io-functions-services-sdk": ^3.39.1
     "@pagopa/logger": 1.0.1
     "@pagopa/openapi-codegen-ts": ^12.2.0
     "@pagopa/ts-commons": ^10.14.2
@@ -4398,14 +4398,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagopa/io-functions-services-sdk@npm:^3.27.0":
-  version: 3.27.0
-  resolution: "@pagopa/io-functions-services-sdk@npm:3.27.0"
+"@pagopa/io-functions-services-sdk@npm:^3.39.1":
+  version: 3.39.1
+  resolution: "@pagopa/io-functions-services-sdk@npm:3.39.1"
   dependencies:
     "@pagopa/ts-commons": ^10.0.0
     fp-ts: ^2.10.5
     io-ts: ^2.2.16
-  checksum: 1bfbad3050bf2ef4f766f567f94709e9d92bc368d83e2da871485c0afcbcb1f9ae682e24eeb2e4f9cc1fa7814edcb915180233b79ea734d94e52c114d0567fc8
+  checksum: 7482235387b47f1ae6b8109da87990109889cbd5ae8ff7b0446cbe44c572fce6851a6d45f4e9a9aabff31b380f65ca484141bcb25647185df83800a294ce66ea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
1. Added `configuration_id` (populated by reading the environment) to the request body of `submitMessageforUserWithFiscalCodeInBody `

<!--- Describe your changes in detail -->

#### Motivation and Context
The `configuration_id` field will be soon mandatory for all `io-services` consumer

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
This change was tested manually (e2e)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
