### PR TITLE
fix: set vatNumber in sc-contracts as optional field

### DIFF
--- a/.changeset/chilled-fishes-sip.md
+++ b/.changeset/chilled-fishes-sip.md
@@ -1,0 +1,6 @@
+---
+"io-sign-backoffice-func": patch
+"@io-sign/io-sign": patch
+---
+
+Set vatNumber in sc-contracts as optional field

--- a/apps/io-sign-backoffice-func/src/infra/selfcare/contract.ts
+++ b/apps/io-sign-backoffice-func/src/infra/selfcare/contract.ts
@@ -10,9 +10,11 @@ const contractSchema = z.object({
     digitalAddress: z.string().min(1),
     taxCode: z.string().min(1),
   }),
-  billing: z.object({
-    vatNumber: z.string().min(1),
-  }),
+  billing: z
+    .object({
+      vatNumber: z.string().min(1).optional(),
+    })
+    .optional(),
   product: z.literal("prod-io-sign"),
 });
 

--- a/packages/io-sign/src/institution.ts
+++ b/packages/io-sign/src/institution.ts
@@ -35,9 +35,11 @@ export type User = z.infer<typeof userSchema>;
 const onboardingSchema = z.object({
   productId: z.string().min(1),
   status: z.string().min(1),
-  billing: z.object({
-    vatNumber: z.string().min(1),
-  }),
+  billing: z
+    .object({
+      vatNumber: z.string().min(1).optional(),
+    })
+    .optional(),
 });
 
 type Onboarding = z.infer<typeof onboardingSchema>;
@@ -57,7 +59,7 @@ export const institutionDetailSchema = z
     ...fields,
     name,
     vatNumber:
-      getIOSignOnboarding(onboarding)?.billing.vatNumber ?? fields.taxCode,
+      getIOSignOnboarding(onboarding)?.billing?.vatNumber ?? fields.taxCode,
   }));
 
 export type InstitutionDetail = z.infer<typeof institutionDetailSchema>;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

The `billing` and `vatNumber` properties in the `contractSchema` and `onboardingSchema`  have become optional

#### Motivation and Context

In the message arriving on the `sc-contracts` queue, the `billing` property has become optional, as well as the `vatNumber` property in `billing`

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
