### PR TITLE
fix: set taxCode in sc-contracts as optional field

### DIFF
--- a/apps/io-sign-backoffice-app/src/lib/auth/use-cases.ts
+++ b/apps/io-sign-backoffice-app/src/lib/auth/use-cases.ts
@@ -33,7 +33,7 @@ export let authenticate = async (idToken: string) => {
       throw new Error(`Institution ${institutionId} does not exists`);
     }
     await createIssuerIfNotExists({
-      id: institution.taxCode,
+      id: institutionId,
       institutionId,
       supportEmail: institution.supportEmail,
       name: institution.name,
@@ -67,7 +67,7 @@ if (process.env.NODE_ENV === "development") {
       vatNumber: "0010213",
     };
     await createIssuerIfNotExists({
-      id: institution.taxCode,
+      id: institution.id,
       institutionId: institution.id,
       supportEmail: institution.supportEmail,
       name: institution.name,

--- a/apps/io-sign-backoffice-func/src/infra/handlers/__test__/get-api-key.spec.ts
+++ b/apps/io-sign-backoffice-func/src/infra/handlers/__test__/get-api-key.spec.ts
@@ -32,7 +32,7 @@ const apiKey: ApiKey = {
 };
 
 const issuer: Issuer = {
-  id: institution.taxCode,
+  id: institution.id,
   status: "active",
   type: "PA",
   institutionId: institution.id,

--- a/apps/io-sign-backoffice-func/src/infra/handlers/__test__/on-selfcare-contracts-message.spec.ts
+++ b/apps/io-sign-backoffice-func/src/infra/handlers/__test__/on-selfcare-contracts-message.spec.ts
@@ -21,7 +21,7 @@ const auth = new google.auth.GoogleAuth({
 });
 
 const issuer: Issuer = {
-  id: "id",
+  id: "27e11a61-85bb-4dd5-95ff-d7f337058d99",
   type: "PA",
   externalId: "externalId",
   institutionId: "27e11a61-85bb-4dd5-95ff-d7f337058d99",

--- a/apps/io-sign-backoffice-func/src/infra/handlers/on-selfcare-contracts-message.ts
+++ b/apps/io-sign-backoffice-func/src/infra/handlers/on-selfcare-contracts-message.ts
@@ -26,7 +26,7 @@ const sendOnboardingMessage = ({
 }: ActiveIoSignContract) =>
   pipe(
     issuerAlreadyExists({
-      id: institution.taxCode,
+      id: internalIstitutionID,
       institutionId: internalIstitutionID,
     }),
     RTE.filterOrElse(

--- a/apps/io-sign-backoffice-func/src/infra/selfcare/contract.ts
+++ b/apps/io-sign-backoffice-func/src/infra/selfcare/contract.ts
@@ -8,7 +8,7 @@ const contractSchema = z.object({
     address: z.string().min(1),
     description: z.string().min(1),
     digitalAddress: z.string().min(1),
-    taxCode: z.string().min(1),
+    taxCode: z.string().min(1).optional(),
   }),
   billing: z.object({
     vatNumber: z.string().min(1),

--- a/apps/io-sign-backoffice-func/src/institution.ts
+++ b/apps/io-sign-backoffice-func/src/institution.ts
@@ -29,4 +29,4 @@ export const getInstitutionById = (id: string) => (r: InstitutionEnvironment) =>
 
 export const getIssuerByInstitution = (
   institution: Pick<InstitutionDetail, "id" | "taxCode">
-) => getIssuer({ id: institution.taxCode, institutionId: institution.id });
+) => getIssuer({ id: institution.id, institutionId: institution.id });

--- a/packages/io-sign/src/institution.ts
+++ b/packages/io-sign/src/institution.ts
@@ -48,7 +48,7 @@ export const getIOSignOnboarding = (list: Onboarding[]) =>
 export const institutionDetailSchema = z
   .object({
     id: z.string().uuid(),
-    taxCode: z.string().min(1),
+    taxCode: z.string().min(1).optional(),
     supportEmail: z.string(),
     description: z.string().min(1),
     onboarding: z.array(onboardingSchema),
@@ -56,8 +56,7 @@ export const institutionDetailSchema = z
   .transform(({ description: name, onboarding, ...fields }) => ({
     ...fields,
     name,
-    vatNumber:
-      getIOSignOnboarding(onboarding)?.billing.vatNumber ?? fields.taxCode,
+    vatNumber: getIOSignOnboarding(onboarding)?.billing.vatNumber ?? fields.id,
   }));
 
 export type InstitutionDetail = z.infer<typeof institutionDetailSchema>;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

The `taxCode` property in the `contractSchema` and `institutionDetailSchema ` have become optional

#### Motivation and Context

In the message arriving on the `sc-contracts` queue, the `taxCode` property in `institution` has become optional

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
