### PR TITLE
[CES-112] Switch Cosmos secondary location to ItalyNorth

### DIFF
--- a/infra/resources/prod/terraform.tfvars
+++ b/infra/resources/prod/terraform.tfvars
@@ -41,9 +41,9 @@ cosmos = {
   zone_redundant = false
   additional_geo_locations = [
     {
-      location          = "northeurope"
+      location          = "italynorth"
       failover_priority = 1
-      zone_redundant    = false
+      zone_redundant    = true
     }
   ]
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Replace NorthEurope with ItalyNorth region for data redundancy in read-only mode

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

ItalyNorth migration. This is a first step to have data in ItalyNorth without affecting operations on the main region, WestEurope

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
