### PR TITLE
[CES-112] Add private endpoints to Cosmos Account without altering DNS

### DIFF
--- a/infra/identity/prod/README.md
+++ b/infra/identity/prod/README.md
@@ -19,6 +19,7 @@ No providers.
 | <a name="module_federated_identities"></a> [federated\_identities](#module\_federated\_identities) | github.com/pagopa/dx//infra/modules/azure_federated_identity_with_github | main |
 | <a name="module_federated_identities_opex"></a> [federated\_identities\_opex](#module\_federated\_identities\_opex) | github.com/pagopa/dx//infra/modules/azure_federated_identity_with_github | main |
 | <a name="module_federated_identities_web_apps"></a> [federated\_identities\_web\_apps](#module\_federated\_identities\_web\_apps) | github.com/pagopa/dx//infra/modules/azure_federated_identity_with_github | main |
+| <a name="module_roles_ci"></a> [roles\_ci](#module\_roles\_ci) | github.com/pagopa/dx//infra/modules/azure_role_assignments | main |
 
 ## Resources
 

--- a/infra/resources/prod/locals.tf
+++ b/infra/resources/prod/locals.tf
@@ -1,4 +1,5 @@
 locals {
-  project = format("%s-%s-%s", var.prefix, var.env_short, var.domain)
-  product = format("%s-%s", var.prefix, var.env_short)
+  project     = format("%s-%s-%s", var.prefix, var.env_short, var.domain)
+  product     = format("%s-%s", var.prefix, var.env_short)
+  project_itn = "${local.product}-itn"
 }

--- a/infra/resources/prod/network.tf
+++ b/infra/resources/prod/network.tf
@@ -15,7 +15,7 @@ data "azurerm_subnet" "private_endpoints_subnet" {
 }
 
 data "azurerm_subnet" "itn_private_endpoints_subnet" {
-  name                 = format("%s-itn-pep-snet-01", local.product)
+  name                 = "${local.project_itn}-pep-snet-01"
   virtual_network_name = data.azurerm_virtual_network.itn_vnet_common.name
   resource_group_name  = data.azurerm_virtual_network.itn_vnet_common.resource_group_name
 }
@@ -442,4 +442,17 @@ resource "azurerm_private_endpoint" "io_sign_backoffice_func_staging" {
   }
 
   tags = var.tags
+}
+
+resource "azurerm_private_endpoint" "cosno_itn" {
+  name                = "${local.project_itn}-sign-cosno-pep-01"
+  location            = "italynorth"
+  resource_group_name = azurerm_resource_group.data_rg.name
+  subnet_id           = data.azurerm_subnet.itn_private_endpoints_subnet.id
+
+  private_service_connection {
+    name                           = "${local.project_itn}-sign-cosno-pep-01"
+    private_connection_resource_id = module.cosmosdb_account.id
+    is_manual_connection           = false
+  }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Add private endpoints to the following Cosmos DB Accounts:

- io-p-sign-cosmos

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The new private endpoints are located in ItalyNorth region and will be used when we will run the region failover between ItalyNorth and WestEurope. These new PEPs allow applications running in ItalyNorth to not routing packets towards WestEurope, gaining in performances

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
