### PR TITLE
[CES-112] Fix Private Endpoint definition for Cosmos DB

### DIFF
--- a/infra/resources/prod/network.tf
+++ b/infra/resources/prod/network.tf
@@ -454,7 +454,7 @@ resource "azurerm_private_endpoint" "cosno_itn" {
     name                           = "${local.project_itn}-sign-cosno-pep-01"
     private_connection_resource_id = module.cosmosdb_account.id
     is_manual_connection           = false
-    subresource_names              = ["sql"]
+    subresource_names              = ["Sql"]
   }
 
   tags = var.tags

--- a/infra/resources/prod/network.tf
+++ b/infra/resources/prod/network.tf
@@ -454,5 +454,8 @@ resource "azurerm_private_endpoint" "cosno_itn" {
     name                           = "${local.project_itn}-sign-cosno-pep-01"
     private_connection_resource_id = module.cosmosdb_account.id
     is_manual_connection           = false
+    subresource_names              = ["sql"]
   }
+
+  tags = var.tags
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Fix the private endpoint definition by adding the missing sub-resource property

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Private endpoints can't work without sub-resource definition. This PEP is defined in ITN region for the io-sign Cosmos DB, but will not be active until the failover won't happen

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
