### PR TITLE
Fix CNAME value for showcase website

### DIFF
--- a/infra/resources/prod/terraform.tfvars
+++ b/infra/resources/prod/terraform.tfvars
@@ -303,4 +303,4 @@ io_common = {
   vnet_common_name             = "io-p-vnet-common"
 }
 
-landing_cdn_url = "d26ojiou3fuq3h.cloudfront.net"
+landing_cdn_url = "d1z4jrsc2tpogm.cloudfront.net"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Changed the value of the DNS CNAME record firma.io.italia.it to reach a new CDN

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
PAWSBuilder's infrastructure for firma.io.italia.it showcase website has been deleted. This record will now point to a new proxy CDN that redirects to ioapp.it

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
