### PR TITLE
Add x-iosign-spid-level header to createSignature endpoint

### DIFF
--- a/.changeset/wicked-cooks-fold.md
+++ b/.changeset/wicked-cooks-fold.md
@@ -1,0 +1,5 @@
+---
+"io-func-sign-user": minor
+---
+
+Add optional x-iosign-spid-level header to the POST /signatures endpoint

--- a/apps/io-func-sign-user/openapi.yaml
+++ b/apps/io-func-sign-user/openapi.yaml
@@ -154,6 +154,14 @@ paths:
             minLength: 1
             example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
           required: true
+        - in: header
+          name: x-iosign-spid-level
+          schema:
+            type: string
+            description: The SPID level of the authenticated user.
+            minLength: 1
+            example: https://www.spid.gov.it/SpidL2
+          required: false
         - name: x-pagopa-lollipop-original-method
           in: header
           description: The method of the endpoint called by IO app

--- a/apps/io-func-sign-user/openapi.yaml
+++ b/apps/io-func-sign-user/openapi.yaml
@@ -159,7 +159,10 @@ paths:
           schema:
             type: string
             description: The SPID level of the authenticated user.
-            minLength: 1
+            enum:
+              - https://www.spid.gov.it/SpidL1
+              - https://www.spid.gov.it/SpidL2
+              - https://www.spid.gov.it/SpidL3
             example: https://www.spid.gov.it/SpidL2
           required: false
         - name: x-pagopa-lollipop-original-method


### PR DESCRIPTION
#### List of Changes

Add the optional `x-iosign-spid-level` header to the `POST /signatures` (`createSignature`) operation in the OpenAPI spec.

#### Motivation and Context

The IO backend needs to forward the authenticated user's SPID level to the io-sign user function. This change documents the new header in the API contract so that io-sign can receive it. The header is currently marked as optional (`required: false`) since no business logic consumes it yet on the io-sign side.

#### How Has This Been Tested?

The change is limited to the OpenAPI specification. No runtime logic was modified, so no additional testing is required at this stage.

#### Screenshots (if appropriate):

N/A

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Resolves IEL-501