### PR TITLE
Init switch to ITN for uploaded-documents with double trigger (WEU - ITN)

### DIFF
--- a/.changeset/seven-turkeys-flow.md
+++ b/.changeset/seven-turkeys-flow.md
@@ -1,0 +1,5 @@
+---
+"io-func-sign-issuer": patch
+---
+
+Init switch to ITN for uploaded-documents with double trigger (WEU - ITN)

--- a/apps/io-func-sign-issuer/src/app/main.ts
+++ b/apps/io-func-sign-issuer/src/app/main.ts
@@ -119,12 +119,21 @@ const uploadedContainerClient = new ContainerClient(
   "uploaded-documents"
 );
 
+const uploadedContainerClientItn = new ContainerClient(
+  config.azure.storage.connectionStringItn,
+  "uploaded-documents"
+);
+
 const validatedContainerClient = new ContainerClient(
   config.azure.storage.connectionString,
   "validated-documents"
 );
 
 const uploadedFileStorage = new BlobStorageFileStorage(uploadedContainerClient);
+
+const uploadedFileStorageItn = new BlobStorageFileStorage(
+  uploadedContainerClientItn
+);
 
 const validatedFileStorage = new BlobStorageFileStorage(
   validatedContainerClient
@@ -180,7 +189,7 @@ app.http("getSignerByFiscalCode", {
 
 const getUploadUrl = GetUploadUrlFunction({
   db: database,
-  uploadedContainerClient,
+  uploadedContainerClient: uploadedContainerClientItn,
   issuerRepository
 });
 
@@ -349,6 +358,20 @@ app.storageBlob("validateUpload", {
   path: "uploaded-documents/{name}",
   connection: "StorageAccountConnectionString",
   handler: validateUpload
+});
+
+const validateUploadItn = makeValidateUploadBlobHandler({
+  signatureRequestRepository,
+  uploadMetadataRepository,
+  uploadedFileStorage: uploadedFileStorageItn,
+  validatedFileStorage: validatedFileStorage,
+  eventAnalyticsClient
+});
+
+app.storageBlob("validateUploadItn", {
+  path: "uploaded-documents/{name}",
+  connection: "StorageAccountItnConnectionString",
+  handler: validateUploadItn
 });
 
 // ---- COSMOS DB TRIGGER ----

--- a/apps/io-func-sign-issuer/src/app/use-cases/validate-upload.ts
+++ b/apps/io-func-sign-issuer/src/app/use-cases/validate-upload.ts
@@ -210,7 +210,6 @@ export const validateUpload = (
           RTE.chainW(({ documentMetadata }) =>
             pipe(
               getUploadedDocumentUrl(meta.id),
-              RTE.fromReader,
               RTE.chainW(createDocumentFromUrl(meta.documentId)),
               RTE.chainEitherKW((url) =>
                 pipe(

--- a/apps/io-func-sign-issuer/src/infra/azure/storage/upload.ts
+++ b/apps/io-func-sign-issuer/src/infra/azure/storage/upload.ts
@@ -71,7 +71,16 @@ export class BlobStorageFileStorage implements FileStorage {
 
   getUrl(filename: string) {
     const blobClient = this.#containerClient.getBlobClient(filename);
-    return blobClient.url;
+    return pipe(
+      blobClient,
+      generateSasUrlFromBlob(
+        pipe(
+          defaultBlobGenerateSasUrlOptions(),
+          withPermissions("r"),
+          withExpireInMinutes(5)
+        )
+      )
+    );
   }
 }
 

--- a/apps/io-func-sign-issuer/src/upload.ts
+++ b/apps/io-func-sign-issuer/src/upload.ts
@@ -5,7 +5,6 @@ import * as t from "io-ts";
 
 import * as RTE from "fp-ts/lib/ReaderTaskEither";
 import * as TE from "fp-ts/lib/TaskEither";
-import * as R from "fp-ts/lib/Reader";
 import * as E from "fp-ts/lib/Either";
 import * as O from "fp-ts/lib/Option";
 
@@ -123,7 +122,7 @@ export type FileStorage = {
     filename: string
   ) => TE.TaskEither<Error, string>;
   remove: (filename: string) => TE.TaskEither<Error, void>;
-  getUrl: (filename: string) => string;
+  getUrl: (filename: string) => TE.TaskEither<Error, string>;
 };
 
 export const getUploadedDocument =
@@ -172,6 +171,12 @@ export const createDocumentFromUrl =
     storage.createFromUrl(url, filename);
 
 export const getUploadedDocumentUrl =
-  (uploadId: string): R.Reader<{ uploadedFileStorage: FileStorage }, string> =>
+  (
+    uploadId: string
+  ): RTE.ReaderTaskEither<
+    { uploadedFileStorage: FileStorage },
+    Error,
+    string
+  > =>
   ({ uploadedFileStorage: storage }) =>
     storage.getUrl(uploadId);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
beginCopyFromURL uses SAS url instead of plain url to copy from different storages (to revert after migration completed).
Implemented both uploaded-documents blob triggers for WEU and ITN for old SAS generated upload link.

Resolves IEL-310
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
