### PR TITLE
Add a method to truncate the message subject if it is longer than 121 characters

### DIFF
--- a/.changeset/curvy-llamas-trade.md
+++ b/.changeset/curvy-llamas-trade.md
@@ -1,0 +1,6 @@
+---
+"io-func-sign-issuer": minor
+"@io-sign/io-sign": minor
+---
+
+add a method to truncate the message subject if it is longer than 121 characters

--- a/apps/io-func-sign-issuer/src/app/use-cases/close-signature-request.ts
+++ b/apps/io-func-sign-issuer/src/app/use-cases/close-signature-request.ts
@@ -8,6 +8,7 @@ import {
   sendBillingEvent
 } from "@io-sign/io-sign/event";
 import { NotificationMessage } from "@io-sign/io-sign/notification";
+import { truncateWithEllipsis } from "@io-sign/io-sign/utility";
 
 import { SignatureRequestSigned } from "@io-sign/io-sign/signature-request";
 import { sendTelemetryEvent } from "@io-sign/io-sign/telemetry";
@@ -27,19 +28,25 @@ import { sendSignatureRequestNotification } from "../../signature-request-notifi
 // - the user should be notified by a Message
 // - we should send a "CANCELLED" event to analytics
 
+const truncateTo121Chars = truncateWithEllipsis();
+
 const buildNotificationMessage = (
   request: SignatureRequest
 ): NotificationMessage => {
   const supportEmail = `[${request.issuerEmail}](mailto:${request.issuerEmail})`;
   if (request.status === "SIGNED") {
     return {
-      subject: `Ecco i documenti firmati - ${request.issuerDescription}`,
+      subject: truncateTo121Chars(
+        `Ecco i documenti firmati - ${request.issuerDescription}`
+      ),
       markdown: `I documenti che hai firmato sono pronti!\n\n\nHai **90 giorni** dalla ricezione di questo messaggio per visualizzarli e salvarli sul tuo dispositivo.\n\n\nSe hai dei problemi che riguardano il contenuto del documento, scrivi a ${supportEmail}.`,
       signatureRequestId: request.id
     };
   }
   return {
-    subject: `C'è un problema con la firma dei documenti - ${request.issuerDescription}`,
+    subject: truncateTo121Chars(
+      `C'è un problema con la firma dei documenti - ${request.issuerDescription}`
+    ),
     markdown: `Per un problema tecnico, non è stato possibile completare la firma dei documenti.\n\n\nAttendi un nuovo messaggio per firmare. Se non lo ricevi, puoi contattare l'ente all'indirizzo ${supportEmail}.`
   };
 };

--- a/apps/io-func-sign-issuer/src/app/use-cases/send-notification.ts
+++ b/apps/io-func-sign-issuer/src/app/use-cases/send-notification.ts
@@ -23,15 +23,21 @@ import {
 
 import { Dossier, GetDossier } from "../../dossier";
 
+import { truncateWithEllipsis } from "@io-sign/io-sign/utility";
+
 import {
   MakeMessageContent,
   makeSendSignatureRequestNotification,
   SendNotificationPayload
 } from "../../signature-request-notification";
 
+const truncateTo121Chars = truncateWithEllipsis();
+
 const requestToSignMessage: MakeMessageContent =
   (dossier: Dossier) => (signatureRequest: SignatureRequest) => ({
-    subject: `Hai un documento da firmare - ${signatureRequest.issuerDescription}`,
+    subject: truncateTo121Chars(
+      `Hai un documento da firmare - ${signatureRequest.issuerDescription}`
+    ),
     markdown: `---\nit:\n    cta_1: \n        text: "Inizia"\n        action: "ioit://FCI_MAIN?signatureRequestId=${
       signatureRequest.id
     }"\nen:\n    cta_1: \n        text: "Start"\n        action: "ioit://FCI_MAIN?signatureRequestId=${

--- a/packages/io-sign/src/__test__/utility.spec.ts
+++ b/packages/io-sign/src/__test__/utility.spec.ts
@@ -3,7 +3,11 @@ import { describe, it, expect } from "vitest";
 import * as E from "fp-ts/lib/Either";
 import { identity, pipe } from "fp-ts/lib/function";
 
-import { stringFromBase64Encode, stringToBase64Encode } from "../utility";
+import {
+  stringFromBase64Encode,
+  stringToBase64Encode,
+  truncateWithEllipsis
+} from "../utility";
 
 describe("Utility", () => {
   describe("stringToBase64Encode", () => {
@@ -33,6 +37,30 @@ describe("Utility", () => {
     });
     it("should not convert an invalid base64 string", () => {
       expect(pipe(undefined, stringFromBase64Encode, E.isLeft)).toBe(true);
+    });
+  });
+
+  describe("truncateWithEllipsis", () => {
+    const truncateTo10Chars = truncateWithEllipsis(10);
+
+    it("should leave a string shorter than the limit unchanged", () => {
+      expect(truncateTo10Chars("hello")).toBe("hello");
+    });
+
+    it("should leave a string exactly at the limit unchanged", () => {
+      expect(truncateTo10Chars("1234567890")).toBe("1234567890");
+    });
+
+    it("should truncate a string exceeding the limit and append ellipsis", () => {
+      expect(truncateTo10Chars("12345678901")).toBe("1234567...");
+    });
+
+    it("should truncate to 121 characters (default) including ellipsis", () => {
+      const truncateTo121Chars = truncateWithEllipsis();
+      const long = "Hai un documento da firmare - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec feugiat dapibus nisi gravida semper. Aenean ultrices semper eros non blandit. Pellentesque tincidunt varius metus. Ut pharetra neque ut augue vehicula lobortis. Ut sit amet eros leo. Phasellus quis elit vitae risus posuere sollicitudin eget sed metus.";
+      const result = truncateTo121Chars(long);
+      expect(result.length).toBe(121);
+      expect(result.endsWith("...")).toBe(true);
     });
   });
 });

--- a/packages/io-sign/src/utility.ts
+++ b/packages/io-sign/src/utility.ts
@@ -29,3 +29,8 @@ export const stringFromBase64Encode = (arrayBuffer: unknown) =>
     E.chainW(E.fromNullable(identity)),
     E.mapLeft(() => new Error("Unable to convert base64 string to utf-8"))
   );
+
+export const truncateWithEllipsis =
+  (maxLength = 121) =>
+  (text: string): string =>
+    text.length <= maxLength ? text : `${text.slice(0, maxLength - 3)}...`;


### PR DESCRIPTION
Add a method to truncate the message subject if it is longer than 121 characters

Resolves IEL-418