### PR TITLE
Fix error_trx alert on ITN Event Hub

### DIFF
--- a/infra/italynorth/_modules/event_hub/main.tf
+++ b/infra/italynorth/_modules/event_hub/main.tf
@@ -44,12 +44,12 @@ module "eventhub" {
     },
     error_trx = {
       aggregation = "Total"
-      metric_name = "IncomingMessages"
-      description = "Transactions rejected from one acquirer file received. trx write on eventhub. check immediately"
+      metric_name = "IncomingErrors"
+      description = "Errors on io-sign Event Hub (ITN). Check immediately."
       operator    = "GreaterThan"
       threshold   = 0
       frequency   = "PT5M"
-      window_size = "PT30M"
+      window_size = "PT15M"
     },
   }
 


### PR DESCRIPTION
## What

The `error_trx` metric alert on the new ITN Event Hub was firing on every incoming message because it was using `IncomingMessages > 0` — the same misconfiguration present on WEU.

The WEU alert had been silently broken all along: it had a dimension filter on entity names `bpd-trx-error` and `rtd-trx-error` that don't exist in the io-sign namespace, so it never fired. The ITN copy had no such filter, causing continuous noise from the first ingestion.

## Changes

- Replace `IncomingMessages` with `IncomingErrors` on the `error_trx` alert
- Reduce window size from PT30M to PT15M
- Fix description (was copy-pasted from an acquirer team template)