### PR TITLE
Fix error_trx alert metric name on ITN Event Hub

### DIFF
--- a/infra/italynorth/_modules/event_hub/main.tf
+++ b/infra/italynorth/_modules/event_hub/main.tf
@@ -44,8 +44,8 @@ module "eventhub" {
     },
     error_trx = {
       aggregation = "Total"
-      metric_name = "IncomingErrors"
-      description = "Errors on io-sign Event Hub (ITN). Check immediately."
+      metric_name = "ServerErrors"
+      description = "Server errors on io-sign Event Hub (ITN). Check immediately."
       operator    = "GreaterThan"
       threshold   = 0
       frequency   = "PT5M"


### PR DESCRIPTION
## What

`IncomingErrors` does not exist as a valid metric name for Azure Event Hub namespaces — the Terraform apply failed with a 400 Bad Request.

Replace it with `ServerErrors`, which is the correct metric for server-side errors on Event Hub.