### PR TITLE
Lower no_trx alert threshold on ITN Event Hub

### DIFF
--- a/infra/italynorth/_modules/event_hub/main.tf
+++ b/infra/italynorth/_modules/event_hub/main.tf
@@ -44,8 +44,8 @@ module "eventhub" {
     },
     error_trx = {
       aggregation = "Total"
-      metric_name = "IncomingErrors"
-      description = "Errors on io-sign Event Hub (ITN). Check immediately."
+      metric_name = "ServerErrors"
+      description = "Server errors on io-sign Event Hub (ITN). Check immediately."
       operator    = "GreaterThan"
       threshold   = 0
       frequency   = "PT5M"

--- a/infra/italynorth/_modules/event_hub/main.tf
+++ b/infra/italynorth/_modules/event_hub/main.tf
@@ -27,9 +27,9 @@ module "eventhub" {
     no_trx = {
       aggregation = "Total"
       metric_name = "IncomingMessages"
-      description = "No transactions received from acquirer in the last 24h"
+      description = "No events received on io-sign Event Hub (ITN) in the last 24h"
       operator    = "LessThanOrEqual"
-      threshold   = 1000
+      threshold   = 50
       frequency   = "PT1H"
       window_size = "P1D"
     },


### PR DESCRIPTION
## What

The `no_trx` alert threshold was set to 1000, copy-pasted from an acquirer service template. io-sign averages ~900 msg/day on weekdays and ~200 on weekends, so the alert was firing on normal traffic.

Set threshold to 50 to catch only real blackouts (zero or near-zero ingestion) without false positives on weekends.

Also fix the description which referenced "acquirer" transactions.