### PR TITLE
Update GHA in order to fix "warning Node.js v20 deprecated"

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,31 @@
-io-func-sign-issuer: apps/io-func-sign-issuer/**/*
-io-func-sign-user: apps/io-func-sign-user/**/*
-io-func-sign-support: apps/io-func-sign-support/**/*
-io-sign-selfcare-frontend: apps/io-sign-selfcare-frontend/**/*
-internal: packages/**/*
-docs: docs/**/*
-ci: .github/workflows/**/*
-changeset: .changeset/**/*
+io-func-sign-issuer:
+  - changed-files:
+    - any-glob-to-any-file: "apps/io-func-sign-issuer/**/*"
+
+io-func-sign-user:
+  - changed-files:
+    - any-glob-to-any-file: "apps/io-func-sign-user/**/*"
+
+io-func-sign-support:
+  - changed-files:
+    - any-glob-to-any-file: "apps/io-func-sign-support/**/*"
+
+io-sign-selfcare-frontend:
+  - changed-files:
+    - any-glob-to-any-file: "apps/io-sign-selfcare-frontend/**/*"
+
+internal:
+  - changed-files:
+    - any-glob-to-any-file: "packages/**/*"
+
+docs:
+  - changed-files:
+    - any-glob-to-any-file: "docs/**/*"
+
+ci:
+  - changed-files:
+    - any-glob-to-any-file: ".github/workflows/**/*"
+
+changeset:
+  - changed-files:
+    - any-glob-to-any-file: ".changeset/**/*"

--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Node.js environment
-        uses: pagopa/dx/.github/actions/node-setup@0fd2b15f5b61751fa433be93682e4a48779b600b
+        uses: pagopa/dx/.github/actions/node-setup@7df458f8cbef8c62cf5ebffd0cfe738a98740ece
         env:
           TURBO_CACHE_DIR: .turbo
 

--- a/.github/workflows/deploy-backoffice-func-itn.yaml
+++ b/.github/workflows/deploy-backoffice-func-itn.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   deploy:
     name: Deploy
-    uses: pagopa/dx/.github/workflows/release-azure-appsvc-v1.yaml@fd7c679d7cf2c9f6505cdef7e152086121c41b10
+    uses: pagopa/dx/.github/workflows/release-azure-appsvc-v1.yaml@e392d5787298e8ef0da3fd46a07a4fed65ec4423
     secrets: inherit
     with:
       workspace_name: io-sign-backoffice-func

--- a/.github/workflows/deploy-issuer-func-itn.yaml
+++ b/.github/workflows/deploy-issuer-func-itn.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   deploy_workspace_to_azure:
     name: Deploy
-    uses: pagopa/dx/.github/workflows/release-azure-appsvc-v1.yaml@fd7c679d7cf2c9f6505cdef7e152086121c41b10
+    uses: pagopa/dx/.github/workflows/release-azure-appsvc-v1.yaml@e392d5787298e8ef0da3fd46a07a4fed65ec4423
     secrets: inherit
     with:
       workspace_name: io-func-sign-issuer

--- a/.github/workflows/deploy-support-func-itn.yaml
+++ b/.github/workflows/deploy-support-func-itn.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   deploy:
     name: Deploy
-    uses: pagopa/dx/.github/workflows/release-azure-appsvc-v1.yaml@fd7c679d7cf2c9f6505cdef7e152086121c41b10
+    uses: pagopa/dx/.github/workflows/release-azure-appsvc-v1.yaml@e392d5787298e8ef0da3fd46a07a4fed65ec4423
     secrets: inherit
     with:
       workspace_name: io-func-sign-support

--- a/.github/workflows/deploy-user-func-itn.yaml
+++ b/.github/workflows/deploy-user-func-itn.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   deploy:
     name: Deploy
-    uses: pagopa/dx/.github/workflows/release-azure-appsvc-v1.yaml@fd7c679d7cf2c9f6505cdef7e152086121c41b10
+    uses: pagopa/dx/.github/workflows/release-azure-appsvc-v1.yaml@e392d5787298e8ef0da3fd46a07a4fed65ec4423
     secrets: inherit
     with:
       workspace_name: io-func-sign-user

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -17,13 +17,13 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/labeler@ba790c862c380240c6d5e7427be5ace9a05c754b #v4.0.3
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
 
       # Note that the following step
       # never removes labels
-      - uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # v6.4.0
+      - uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         id: set-result
         with:
           script: |

--- a/.github/workflows/opex_api_backoffice.yaml
+++ b/.github/workflows/opex_api_backoffice.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         id: checkout
         # from https://github.com/actions/checkout/commits/main
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/opex_api_backoffice.yaml
+++ b/.github/workflows/opex_api_backoffice.yaml
@@ -28,8 +28,8 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        # from https://github.com/actions/checkout/commits/main
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # from https://github.com/actions/checkout/releases/tag/v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/opex_api_backoffice_review.yaml
+++ b/.github/workflows/opex_api_backoffice_review.yaml
@@ -22,8 +22,8 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        # from https://github.com/actions/checkout/commits/main
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # from https://github.com/actions/checkout/releases/tag/v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/opex_api_backoffice_review.yaml
+++ b/.github/workflows/opex_api_backoffice_review.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         id: checkout
         # from https://github.com/actions/checkout/commits/main
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/opex_api_issuer.yaml
+++ b/.github/workflows/opex_api_issuer.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         id: checkout
         # from https://github.com/actions/checkout/commits/main
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/opex_api_issuer.yaml
+++ b/.github/workflows/opex_api_issuer.yaml
@@ -28,8 +28,8 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        # from https://github.com/actions/checkout/commits/main
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # from https://github.com/actions/checkout/releases/tag/v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/opex_api_issuer_review.yaml
+++ b/.github/workflows/opex_api_issuer_review.yaml
@@ -22,8 +22,8 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        # from https://github.com/actions/checkout/commits/main
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # from https://github.com/actions/checkout/releases/tag/v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/opex_api_issuer_review.yaml
+++ b/.github/workflows/opex_api_issuer_review.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         id: checkout
         # from https://github.com/actions/checkout/commits/main
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/opex_api_support.yaml
+++ b/.github/workflows/opex_api_support.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         id: checkout
         # from https://github.com/actions/checkout/commits/main
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/opex_api_support.yaml
+++ b/.github/workflows/opex_api_support.yaml
@@ -28,8 +28,8 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        # from https://github.com/actions/checkout/commits/main
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # from https://github.com/actions/checkout/releases/tag/v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/opex_api_support_review.yaml
+++ b/.github/workflows/opex_api_support_review.yaml
@@ -22,8 +22,8 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        # from https://github.com/actions/checkout/commits/main
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # from https://github.com/actions/checkout/releases/tag/v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/opex_api_support_review.yaml
+++ b/.github/workflows/opex_api_support_review.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         id: checkout
         # from https://github.com/actions/checkout/commits/main
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/opex_api_user.yaml
+++ b/.github/workflows/opex_api_user.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         id: checkout
         # from https://github.com/actions/checkout/commits/main
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/opex_api_user.yaml
+++ b/.github/workflows/opex_api_user.yaml
@@ -28,8 +28,8 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        # from https://github.com/actions/checkout/commits/main
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # from https://github.com/actions/checkout/releases/tag/v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/opex_api_user_review.yaml
+++ b/.github/workflows/opex_api_user_review.yaml
@@ -22,8 +22,8 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        # from https://github.com/actions/checkout/commits/main
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # from https://github.com/actions/checkout/releases/tag/v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/opex_api_user_review.yaml
+++ b/.github/workflows/opex_api_user_review.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         id: checkout
         # from https://github.com/actions/checkout/commits/main
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js environment
-        uses: pagopa/dx/.github/actions/node-setup@0fd2b15f5b61751fa433be93682e4a48779b600b
+        uses: pagopa/dx/.github/actions/node-setup@7df458f8cbef8c62cf5ebffd0cfe738a98740ece
         env:
           TURBO_CACHE_DIR: .turbo
 


### PR DESCRIPTION
Update GHA in order to fix "warning Node.js v20 deprecated"

Resolves IEL-528