### PR TITLE
ci: upgrade GHA actions to node24 (checkout v6.0.2, github-script v9)

### DIFF
--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
 

--- a/.github/workflows/deploy-issuer-func-itn.yaml
+++ b/.github/workflows/deploy-issuer-func-itn.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete old tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             github.rest.git.deleteRef({
@@ -36,7 +36,7 @@ jobs:
             })
         continue-on-error: true
       - name: Create tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             github.rest.git.createRef({

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions still running on Node.js 20 (deprecated) to versions using Node.js 24.

### Changes

- `actions/checkout@v3` → `@de0fac2e` (v6.0.2, node24) in `release.yaml` and `code-review.yaml`
- `actions/github-script@v7` → `@3a2844b7` (v9, node24) in `deploy-issuer-func-itn.yaml`

### Context

GitHub will deprecate Node.js 20 in Actions starting June 2nd, 2026 (removed September 16th, 2026).

> **Note:** the remaining warning about `actions/cache@v4.2.3` (node20) in the `itn-tf-code-review.yaml` workflow originates from `pagopa/dx/.github/workflows/infra_plan.yaml` and requires a fix upstream in the `pagopa/dx` repository.