### PR TITLE
Log x-iosign-spid-level header value on createSignature

### DIFF
--- a/apps/io-func-sign-user/src/infra/http/handlers/create-signature.ts
+++ b/apps/io-func-sign-user/src/infra/http/handlers/create-signature.ts
@@ -73,6 +73,13 @@ export const CreateSignatureHandler = H.of((req: H.HttpRequest) =>
       })
     ),
     RTE.chainFirstIOK(() =>
+      L.info("x-iosign-spid-level header", {
+        spidLevel: req.headers["x-iosign-spid-level"] ?? "missing"
+      })({
+        logger: ConsoleLogger
+      })
+    ),
+    RTE.chainFirstIOK(() =>
       L.info("creating signature")({
         logger: ConsoleLogger
       })


### PR DESCRIPTION
Adds a temporary `L.info` log at the start of `CreateSignatureHandler` to inspect the value of the `x-iosign-spid-level` header sent by io-backend in production.

This is a short-lived debug branch to verify whether io-backend correctly forwards the SPID level header before deploying the L3 enforcement logic (#585).

After verification, this branch and the log must be removed.