### PR TITLE
Remove x-iosign-spid-level debug log

### DIFF
--- a/apps/io-func-sign-user/src/infra/http/handlers/create-signature.ts
+++ b/apps/io-func-sign-user/src/infra/http/handlers/create-signature.ts
@@ -73,13 +73,6 @@ export const CreateSignatureHandler = H.of((req: H.HttpRequest) =>
       })
     ),
     RTE.chainFirstIOK(() =>
-      L.info("x-iosign-spid-level header", {
-        spidLevel: req.headers["x-iosign-spid-level"] ?? "missing"
-      })({
-        logger: ConsoleLogger
-      })
-    ),
-    RTE.chainFirstIOK(() =>
       L.info("creating signature")({
         logger: ConsoleLogger
       })


### PR DESCRIPTION
Reverts the temporary debug log introduced in #629.

Merge only after #629 has been merged and the header value has been verified in production.