### PR TITLE
Test extended SAS URL duration for a specific issuer

### DIFF
--- a/.changeset/light-dogs-marry.md
+++ b/.changeset/light-dogs-marry.md
@@ -1,0 +1,5 @@
+---
+"io-func-sign-user": patch
+---
+
+Test nonce duration with sas url

--- a/apps/io-func-sign-user/src/infra/http/handlers/get-signature-request.ts
+++ b/apps/io-func-sign-user/src/infra/http/handlers/get-signature-request.ts
@@ -36,10 +36,15 @@ const grantReadAccessToDocuments =
         TE.map((documents) => ({ ...request, documents }))
       );
     }
+    const sasMinutes =
+      process.env["LONG_SAS_ISSUER_ID"] !== undefined &&
+      request.issuerId === process.env["LONG_SAS_ISSUER_ID"]
+        ? 55
+        : 5;
     return pipe(
       request.documents,
       A.traverse(TE.ApplicativePar)((doc) =>
-        toDocumentWithSasUrlWithFallback("r", 5)(doc)(
+        toDocumentWithSasUrlWithFallback("r", sasMinutes)(doc)(
           r.validatedContainerClient
         )
       ),


### PR DESCRIPTION
## Summary

Adds a runtime-configurable override to extend the SAS URL validity for non-signed documents from 5 to 55 minutes, scoped to a specific issuer.

The behavior is controlled by the env var `LONG_SAS_ISSUER_ID`: when set, any signature request whose `issuerId` matches will receive 55-minute SAS URLs for validated documents. Signed documents are unaffected (remain at 5 minutes).

The env var is read on every request so it can be toggled at runtime without restarting the function.

This is a temporary debug change to test nonce and document SAS URL duration.