### PR TITLE
Add assertionRef validation before getLcParams on create-signature

### DIFF
--- a/.changeset/shy-donkeys-look.md
+++ b/.changeset/shy-donkeys-look.md
@@ -1,0 +1,5 @@
+---
+"io-func-sign-user": minor
+---
+
+Fix create-signature assertion-ref logic

--- a/apps/io-func-sign-user/src/infra/http/decoders/__test__/lollipop.spec.ts
+++ b/apps/io-func-sign-user/src/infra/http/decoders/__test__/lollipop.spec.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "vitest";
 import * as E from "fp-ts/Either";
 import * as H from "@pagopa/handler-kit";
-import { AssertionTypeEnum } from "../../models/AssertionType";
 import { requireBasicLollipopParams } from "../lollipop";
 
 // A LolliPoP valid SignatureInput with multiple signature
@@ -18,9 +17,7 @@ const mockedLollipopRequest = (aSignatureInput: string): H.HttpRequest => ({
     // NOTE: "x-pagopa-lollipop-auth-jwt" is intentionally absent — it is
     // no longer required by requireBasicLollipopParams since the bearer JWT
     // is now generated internally via the Lollipop internal API.
-    "x-pagopa-lollipop-assertion-ref": "sha256-anAssertionRef",
-    "x-pagopa-lollipop-assertion-type": AssertionTypeEnum.SAML,
-    "x-pagopa-lollipop-public-key": "aPubkey"
+    "x-iosign-assertion-ref": "sha256-anAssertionRef"
   },
   body: undefined
 });

--- a/apps/io-func-sign-user/src/infra/http/decoders/lollipop.ts
+++ b/apps/io-func-sign-user/src/infra/http/decoders/lollipop.ts
@@ -10,8 +10,6 @@ import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { LollipopSignatureInput } from "../models/LollipopSignatureInput";
 import { LollipopSignature } from "../models/LollipopSignature";
 import { LollipopAssertionRef } from "../models/LollipopAssertionRef";
-import { AssertionType } from "../models/AssertionType";
-import { LollipopPublicKey } from "../models/LollipopPublicKey";
 
 const requireParameterFromHeader =
   <T>(headerName: string, schema: t.Decoder<unknown, T>) =>
@@ -30,9 +28,7 @@ const requireParameterFromHeader =
 export const BasicLollipopParams = t.type({
   signatureInput: LollipopSignatureInput,
   signature: LollipopSignature,
-  assertionRef: LollipopAssertionRef,
-  assertionType: AssertionType,
-  publicKey: LollipopPublicKey
+  assertionRef: LollipopAssertionRef
 });
 
 export type BasicLollipopParams = t.TypeOf<typeof BasicLollipopParams>;
@@ -65,22 +61,8 @@ export const requireBasicLollipopParams = (
       assertionRef: pipe(
         request,
         requireParameterFromHeader(
-          "x-pagopa-lollipop-assertion-ref",
+          "x-iosign-assertion-ref",
           LollipopAssertionRef
-        )
-      ),
-      assertionType: pipe(
-        request,
-        requireParameterFromHeader(
-          "x-pagopa-lollipop-assertion-type",
-          AssertionType
-        )
-      ),
-      publicKey: pipe(
-        request,
-        requireParameterFromHeader(
-          "x-pagopa-lollipop-public-key",
-          LollipopPublicKey
         )
       )
     })

--- a/apps/io-func-sign-user/src/infra/http/handlers/__test__/create-signature.spec.ts
+++ b/apps/io-func-sign-user/src/infra/http/handlers/__test__/create-signature.spec.ts
@@ -27,9 +27,19 @@ import type { LollipopApiClientInt, LcParams } from "../../../lollipop/lc-params
 vi.mock("../../../lollipop/lc-params", () => ({
   makeGetLcParams: vi.fn()
 }));
-vi.mock("../../../lollipop/assertion", () => ({
-  makeGetBase64SamlAssertion: vi.fn()
-}));
+vi.mock("../../../lollipop/assertion", async () => {
+  const E = await import("fp-ts/lib/Either");
+  return {
+    makeGetBase64SamlAssertion: vi.fn(),
+    getAlgoFromAssertionRef: (assertionRef: string) => assertionRef.split("-")[0],
+    getKeyThumbprintFromSignature: (signatureInput: string) => {
+      const match = /;?keyid="([^"]+)";?/.exec(signatureInput);
+      return match?.[1]
+        ? E.right(match[1])
+        : E.left(new Error('Missing "keyid" in signature-input'));
+    }
+  };
+});
 // namirial/client.ts → fetch-timeout.ts → agent.getHttpFetch
 vi.mock("../../../namirial/client", () => ({
   makeGetToken: vi.fn()
@@ -55,7 +65,8 @@ import { makeGetValidatedEmailByFiscalCode } from "@io-sign/io-sign/infra/io-pro
 // ---------------------------------------------------------------------------
 
 const aFiscalCode = "RSSMRA85T10A562S" as FiscalCode;
-const anAssertionRef = "sha256-n4bQgYhMfWWaL-qgxVrQFaO_TxsrC4Is0V1sFbDwCgg" as NonEmptyString;
+const aThumbprint = "n4bQgYhMfWWaL-qgxVrQFaO_TxsrC4Is0V1sFbDwCgg";
+const anAssertionRef = `sha256-${aThumbprint}` as NonEmptyString;
 const aSigner = { id: newId() };
 
 const aLcParams: LcParams = {
@@ -71,7 +82,7 @@ const aLcParams: LcParams = {
  * ^(?:sig\d+=[^,]*)(?:,\s*(?:sig\d+=[^,]*))*$
  */
 const aValidSignatureInput =
-  `sig1=("@method" "x-pagopa-lollipop-original-url");created=1618884475;nonce="test-nonce-123";keyid="${anAssertionRef}"`;
+  `sig1=("@method" "x-pagopa-lollipop-original-url");created=1618884475;nonce="test-nonce-123";keyid="${aThumbprint}"`;
 
 /** A valid signature value matching: ^((sig[0-9]+)=:[A-Za-z0-9+/=]*:(, ?)?)+$ */
 const aValidSignature = "sig1=:aGVsbG8=:";
@@ -79,7 +90,7 @@ const aValidSignature = "sig1=:aGVsbG8=:";
 const aValidLollipopHeaders = {
   "signature-input": aValidSignatureInput,
   signature: aValidSignature,
-  "x-pagopa-lollipop-assertion-ref": anAssertionRef,
+  "x-iosign-assertion-ref": anAssertionRef,
   "x-pagopa-lollipop-assertion-type": AssertionTypeEnum.SAML,
   "x-pagopa-lollipop-public-key": "a-public-key",
   "x-pagopa-lollipop-custom-tos-challenge": "tos-challenge-value",
@@ -235,7 +246,7 @@ describe("CreateSignatureHandler", () => {
       );
     });
 
-    it("should return 400 when x-pagopa-lollipop-assertion-ref header is missing", async () => {
+    it("should return 400 when x-iosign-assertion-ref header is missing", async () => {
       const req: H.HttpRequest = {
         ...aValidRequest(),
         headers: {
@@ -247,7 +258,7 @@ describe("CreateSignatureHandler", () => {
           "x-pagopa-lollipop-public-key": "a-public-key",
           "x-pagopa-lollipop-custom-tos-challenge": "tos-challenge-value",
           "x-pagopa-lollipop-custom-sign-challenge": "sign-challenge-value"
-          // "x-pagopa-lollipop-assertion-ref" intentionally missing
+          // "x-iosign-assertion-ref" intentionally missing
         }
       };
       const run = CreateSignatureHandler({ ...buildDependencies(), input: req });

--- a/apps/io-func-sign-user/src/infra/http/handlers/create-signature.ts
+++ b/apps/io-func-sign-user/src/infra/http/handlers/create-signature.ts
@@ -52,8 +52,31 @@ import type { LollipopApiClientInt } from "../../lollipop/lc-params";
 import { makeGetLcParams } from "../../lollipop/lc-params";
 import { makeGetValidatedEmailByFiscalCode } from "@io-sign/io-sign/infra/io-profile/profile";
 import type { IoProfileClientWithApiKey } from "@io-sign/io-sign/infra/io-profile/client";
-import { makeGetBase64SamlAssertion } from "../../lollipop/assertion";
+import {
+  getAlgoFromAssertionRef,
+  getKeyThumbprintFromSignature,
+  makeGetBase64SamlAssertion
+} from "../../lollipop/assertion";
 import { getSignatureFromHeaderName } from "../../lollipop/signature";
+import { LollipopAssertionRef } from "../models/LollipopAssertionRef";
+
+const checkAssertionRefMatchesSignature = (
+  assertionRef: LollipopAssertionRef,
+  signatureInput: string
+): E.Either<Error, void> =>
+  pipe(
+    getKeyThumbprintFromSignature(signatureInput),
+    E.chain((keyThumbprint) =>
+      assertionRef ===
+      `${getAlgoFromAssertionRef(assertionRef)}-${keyThumbprint}`
+        ? E.right(undefined)
+        : E.left<Error>(
+            new H.HttpForbiddenError(
+              "AssertionRef does not match the keyid in signature-input"
+            )
+          )
+    )
+  );
 
 export type CreateSignatureDependencies = {
   signerRepository: SignerRepository;
@@ -138,16 +161,24 @@ export const CreateSignatureHandler = H.of((req: H.HttpRequest) =>
           );
 
           return pipe(
-            sequenceS(TE.ApplyPar)({
-              signer: signerRepository.getSignerByFiscalCode(
-                sequence.fiscalCode
-              ),
-              email: getValidatedEmailByFiscalCode(sequence.fiscalCode),
-              lcParams: getLcParams({
-                assertionRef: sequence.lollipopParams.assertionRef,
-                signatureInput: sequence.lollipopParams.signatureInput
+            TE.fromEither(
+              checkAssertionRefMatchesSignature(
+                sequence.lollipopParams.assertionRef,
+                sequence.lollipopParams.signatureInput
+              )
+            ),
+            TE.chainW(() =>
+              sequenceS(TE.ApplyPar)({
+                signer: signerRepository.getSignerByFiscalCode(
+                  sequence.fiscalCode
+                ),
+                email: getValidatedEmailByFiscalCode(sequence.fiscalCode),
+                lcParams: getLcParams({
+                  assertionRef: sequence.lollipopParams.assertionRef,
+                  signatureInput: sequence.lollipopParams.signatureInput
+                })
               })
-            }),
+            ),
             TE.chainW(({ signer, email, lcParams }) =>
               pipe(
                 sequenceS(TE.ApplySeq)({

--- a/apps/io-func-sign-user/src/infra/lollipop/assertion.ts
+++ b/apps/io-func-sign-user/src/infra/lollipop/assertion.ts
@@ -81,3 +81,30 @@ export const makeGetBase64SamlAssertion =
       TE.chainEitherK(stringToBase64Encode),
       TE.chainEitherKW(validate(NonEmptyString, "Saml assertion is not valid"))
     );
+
+// Matches the first `keyid` value in a `signature-input` header
+// e.g. sig1=(...);keyid="sha256-abc...";nonce="xyz"
+const KEY_ID_REGEX = /;?keyid="([^"]+)";?/;
+
+/**
+ * Returns the hash algorithm prefix of an AssertionRef.
+ * e.g. "sha256-abc..." → "sha256"
+ */
+export const getAlgoFromAssertionRef = (
+  assertionRef: LollipopAssertionRef
+): string => assertionRef.split("-")[0];
+
+/**
+ * Extracts the public-key thumbprint from the `keyid` field of a
+ * `signature-input` header value.
+ */
+export const getKeyThumbprintFromSignature = (
+  signatureInput: string
+): E.Either<Error, string> => {
+  const match = KEY_ID_REGEX.exec(signatureInput);
+  return match?.[1]
+    ? E.right(match[1])
+    : E.left(
+        new Error('Missing or invalid "keyid" in "signature-input" header')
+      );
+};

--- a/infra/italynorth/_modules/platform_proxy_api/policies/io_sign/_api_base_policy_rev2.xml
+++ b/infra/italynorth/_modules/platform_proxy_api/policies/io_sign/_api_base_policy_rev2.xml
@@ -51,6 +51,9 @@
         <set-header name="x-iosign-spid-level" exists-action="override">
             <value>@(((JObject)context.Variables["xUserJson"]).GetValue("spid_level")?.ToString() ?? "")</value>
         </set-header>
+        <set-header name="x-iosign-assertion-ref" exists-action="override">
+            <value>@(((JObject)context.Variables["xUserJson"]).GetValue("assertion_ref")?.ToString() ?? "")</value>
+        </set-header>
         <set-header name="x-user" exists-action="delete" />
         <set-backend-service base-url="{{io-sign-user-func-url}}/api/v1/sign" />
         <set-header name="x-functions-key" exists-action="override">


### PR DESCRIPTION
## Summary

Replicate the `assertionRef` security check that was previously performed by io-backend's `expressLollipopMiddleware`, now that `io-func-sign-user` calls the Lollipop internal API directly.

## Changes

### `io-func-sign-user`

**`infra/lollipop/assertion.ts`**
- Add `getAlgoFromAssertionRef` — extracts the hash algorithm prefix (`sha256`, `sha384`, `sha512`) from an `AssertionRef`
- Add `getKeyThumbprintFromSignature` — extracts the `keyid` value from the `signature-input` header via regex

**`infra/http/handlers/create-signature.ts`**
- Add `checkAssertionRefMatchesSignature` helper that verifies:
  ```
  assertionRef (from x-iosign-assertion-ref) === algo-thumbprint (from keyid in signature-input)
  ```
- The check runs before `getLcParams`; returns `403 Forbidden` on mismatch

**`infra/http/decoders/lollipop.ts`** *(pre-existing change)*
- Read `assertionRef` from `x-iosign-assertion-ref` instead of `x-pagopa-lollipop-assertion-ref`
- Remove `assertionType` and `publicKey` from `BasicLollipopParams` (now obtained from `LcParams`)

### `infra/italynorth` (APIM policy)

- Forward `assertion_ref` from the IO session token as `x-iosign-assertion-ref` to the user function

### Tests

- Align `lollipop.spec.ts` and `create-signature.spec.ts` to the updated decoder (`x-iosign-assertion-ref`)
- Fix `keyid` in test fixture to use only the thumbprint (hash without `sha256-` prefix), matching real Lollipop behaviour
- Update `lollipop/assertion` mock to expose the new utility functions