### PR TITLE
Fix blobExists silently passing when blob does not exist

### DIFF
--- a/.changeset/late-suits-nail.md
+++ b/.changeset/late-suits-nail.md
@@ -1,0 +1,5 @@
+---
+"@io-sign/io-sign": patch
+---
+
+Fix blobExists bug

--- a/packages/io-sign/src/infra/azure/storage/blob.ts
+++ b/packages/io-sign/src/infra/azure/storage/blob.ts
@@ -15,9 +15,15 @@ import { pipe } from "fp-ts/lib/function";
 import { addMinutes } from "date-fns";
 
 export const blobExists = (blobClient: BlobClient) =>
-  TE.tryCatch(
-    () => blobClient.exists(),
-    () => new Error("The specified Blob does not exists.")
+  pipe(
+    TE.tryCatch(
+      () => blobClient.exists(),
+      () => new Error("The specified Blob does not exists.")
+    ),
+    TE.filterOrElse(
+      (exists) => exists,
+      () => new Error("The specified Blob does not exists.")
+    )
   );
 
 export const getBlobClient = (blobName: string) =>

--- a/packages/io-sign/src/infra/azure/storage/blob.ts
+++ b/packages/io-sign/src/infra/azure/storage/blob.ts
@@ -15,11 +15,14 @@ import { pipe } from "fp-ts/lib/function";
 import { addMinutes } from "date-fns";
 
 export const blobExists = (blobClient: BlobClient) =>
+  TE.tryCatch(
+    () => blobClient.exists(),
+    () => new Error("The specified Blob does not exists.")
+  );
+
+export const requireBlobExists = (blobClient: BlobClient) =>
   pipe(
-    TE.tryCatch(
-      () => blobClient.exists(),
-      () => new Error("The specified Blob does not exists.")
-    ),
+    blobExists(blobClient),
     TE.filterOrElse(
       (exists) => exists,
       () => new Error("The specified Blob does not exists.")
@@ -29,8 +32,7 @@ export const blobExists = (blobClient: BlobClient) =>
 export const getBlobClient = (blobName: string) =>
   pipe(
     RTE.ask<ContainerClient>(),
-    RTE.map((containerClient) => containerClient.getBlobClient(blobName)),
-    RTE.chainFirstTaskEitherK(blobExists)
+    RTE.map((containerClient) => containerClient.getBlobClient(blobName))
   );
 
 export const defaultBlobGenerateSasUrlOptions =

--- a/packages/io-sign/src/infra/azure/storage/document-content.ts
+++ b/packages/io-sign/src/infra/azure/storage/document-content.ts
@@ -6,7 +6,11 @@ import { pipe } from "fp-ts/lib/function";
 import * as RTE from "fp-ts/ReaderTaskEither";
 import { DocumentReady } from "../../../document";
 
-import { downloadContentFromBlob, getBlobClient, requireBlobExists } from "./blob";
+import {
+  downloadContentFromBlob,
+  getBlobClient,
+  requireBlobExists
+} from "./blob";
 
 export const getDocumentContent = (document: DocumentReady) =>
   pipe(

--- a/packages/io-sign/src/infra/azure/storage/document-content.ts
+++ b/packages/io-sign/src/infra/azure/storage/document-content.ts
@@ -6,7 +6,7 @@ import { pipe } from "fp-ts/lib/function";
 import * as RTE from "fp-ts/ReaderTaskEither";
 import { DocumentReady } from "../../../document";
 
-import { downloadContentFromBlob, getBlobClient } from "./blob";
+import { downloadContentFromBlob, getBlobClient, requireBlobExists } from "./blob";
 
 export const getDocumentContent = (document: DocumentReady) =>
   pipe(
@@ -14,5 +14,6 @@ export const getDocumentContent = (document: DocumentReady) =>
     split("/"),
     last,
     getBlobClient,
+    RTE.chainFirstTaskEitherK(requireBlobExists),
     RTE.chainTaskEitherK(downloadContentFromBlob)
   );

--- a/packages/io-sign/src/infra/azure/storage/document-url.ts
+++ b/packages/io-sign/src/infra/azure/storage/document-url.ts
@@ -10,6 +10,7 @@ import {
   defaultBlobGenerateSasUrlOptions,
   generateSasUrlFromBlob,
   getBlobClient,
+  requireBlobExists,
   withExpireInMinutes,
   withPermissions
 } from "./blob";
@@ -22,6 +23,7 @@ export const toDocumentWithSasUrl =
       split("/"),
       last,
       getBlobClient,
+      RTE.chainFirstTaskEitherK(requireBlobExists),
       RTE.chainTaskEitherK(
         generateSasUrlFromBlob(
           pipe(


### PR DESCRIPTION
## Summary

`blobExists` was using `TE.tryCatch` to wrap `blobClient.exists()`, which returns a `Promise<boolean>`. Since a missing blob resolves to `false` rather than rejecting, `TE.tryCatch` alone produced `Right(false)` instead of `Left(Error)`, allowing the chain to continue silently as if the blob existed.

Additionally, `getBlobClient` was calling `blobExists` unconditionally via `chainFirstTaskEitherK`, making it impossible to obtain a `BlobClient` reference for a blob that does not yet exist. This caused a regression in `create-filled-document`, which intentionally operates on a blob that must be absent before upload.

## Changes

The fix separates two distinct responsibilities:

- **`blobExists`**: kept as a pure boolean check (`TaskEither<Error, boolean>`), consistent with the `FileStorage.exists` contract
- **`requireBlobExists`**: new helper that wraps `blobExists` with `filterOrElse` to fail explicitly (`Left(Error)`) when the blob is missing
- **`getBlobClient`**: now a pure reference constructor with no I/O — constructing a `BlobClient` only requires a name, not a network call
- **`document-url.ts`** and **`document-content.ts`**: use `requireBlobExists` explicitly, since blob existence is a hard prerequisite before generating a SAS URL or downloading content
- **`create-filled-document.ts`**: untouched — its tolerant-absence flow (`deleteBlobIfExist` + `TE.alt` fallback) works correctly again

Resolves IEL-771